### PR TITLE
Add self-contained single-file Urunan app with GitHub Pages deployment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Urunan to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths: [ "urunan.html", ".github/workflows/github-pages.yml" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: prepare site
+        run: |
+          mkdir -p _site
+          cp urunan.html _site/index.html
+
+      - name: setup pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/urunan.html
+++ b/urunan.html
@@ -1,469 +1,726 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <title>Urunan – Split Your Bills</title>
-  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <style>
-    [v-cloak] { display: none; }
-    input, select, button { -webkit-tap-highlight-color: transparent; }
-    body { -webkit-font-smoothing: antialiased; }
-  </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>Urunan</title>
+
+<!-- PWA / Add to Home Screen -->
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<meta name="apple-mobile-web-app-title" content="Urunan">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="theme-color" content="#14b8a6">
+<link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAIAAACyr5FlAAAB2UlEQVR42u3bsQ1AIQhAQYZw/9IZ3E4XsLEDvJ9X/gZyFYkx1pSuhRUIDsEhOASH4BAcgkNwCA7BIcEhOASH4BAcgkNwCA7BITgkOASH4BAcgkNwCA7BITgEh5QUx/7sgwMOOOCAAw444IADDjjggAMOOOCAAw444IADDjjggAMOOOCAAw444IADDjjggAMOOOCAAw444IADDjjggAMOOMrgyPxiDA5rhcNa4bBWU8BhCjhMAYcp4IADDjjgcCGFAw444IADDjjggAMOOOCAAw444IADDhdSOOCAAw44rBUOa4XDWuGwVlPAYQo4TAGHCykccMABBxxwwAEHHHDAAQcccMABBxwupKaAAw444IADDjjggAMOOKwVDmuFw1pN4ULqQgoHHHDAAQcccMABBxxwwAEHHHDAAYfboguptZoCDlPAYQo44IADDjjggAMOOOCAw4XUhRQOOOCAAw444IADDjjggAMOOOCAAw444IADDjjggAMOOOAoiOMVTdf/4YADDjjggAMOOOCAAw444IADDjjggAMOOOCAAw444IADDjjUNzgEh+AQHIJDcAgOwSE4BIfgkOAQHIJDcAgOwSE4BIfgEBwSHIJDcAgOwSE4BIfgEByCQ5oHqtc/gcsl2wcAAAAASUVORK5CYII=">
+
+<style>
+:root {
+  --teal:       #14b8a6;
+  --teal-d:     #0d9488;
+  --teal-50:    #f0fdfa;
+  --teal-100:   #ccfbf1;
+  --teal-700:   #0f766e;
+  --gray-50:    #f9fafb;
+  --gray-100:   #f3f4f6;
+  --gray-200:   #e5e7eb;
+  --gray-300:   #d1d5db;
+  --gray-400:   #9ca3af;
+  --gray-500:   #6b7280;
+  --gray-600:   #4b5563;
+  --gray-700:   #374151;
+  --gray-800:   #1f2937;
+  --red:        #ef4444;
+  --red-50:     #fef2f2;
+  --red-100:    #fee2e2;
+  --green:      #16a34a;
+  --green-100:  #dcfce7;
+  --blue:       #3b82f6;
+  --blue-d:     #2563eb;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  background: var(--gray-50);
+  color: var(--gray-800);
+  -webkit-font-smoothing: antialiased;
+  min-height: 100dvh;
+  -webkit-tap-highlight-color: transparent;
+}
+[v-cloak] { display: none; }
+button, input, select { font-family: inherit; font-size: inherit; }
+input, select { -webkit-appearance: none; appearance: none; }
+
+/* ── Shell ────────────────────────────────── */
+#app {
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Setup screen ─────────────────────────── */
+.setup-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 3rem 0;
+}
+.hero { text-align: center; margin-bottom: 2rem; }
+.hero-icon { font-size: 3.5rem; }
+.hero-title { font-size: 1.875rem; font-weight: 700; color: var(--teal); margin-top: 0.5rem; }
+.hero-sub { color: var(--gray-400); margin-top: 0.25rem; font-size: 0.9375rem; }
+.hero-note { text-align: center; font-size: 0.75rem; color: var(--gray-400); margin-top: 0.75rem; }
+
+/* ── Install banner ───────────────────────── */
+.install-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: var(--teal-50);
+  border: 1px solid var(--teal-100);
+  border-radius: 0.75rem;
+  padding: 0.875rem 1rem;
+  margin-bottom: 1rem;
+}
+.install-banner-text { flex: 1; font-size: 0.8125rem; color: var(--teal-700); line-height: 1.5; }
+.install-banner-text b { display: block; margin-bottom: 0.25rem; }
+.install-close {
+  background: none; border: none; cursor: pointer;
+  color: var(--teal-700); opacity: 0.5; font-size: 1.25rem; line-height: 1; padding: 0; flex-shrink: 0;
+}
+
+/* ── Top bar ──────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0 0.875rem;
+  border-bottom: 1px solid var(--gray-200);
+  margin-bottom: 1rem;
+}
+.topbar-left { display: flex; flex-direction: column; }
+.topbar-name { font-weight: 600; font-size: 0.9375rem; }
+.topbar-email { font-size: 0.75rem; color: var(--gray-400); margin-top: 0.125rem; }
+.back-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1rem 0 0.875rem;
+  border-bottom: 1px solid var(--gray-200);
+  margin-bottom: 1rem;
+}
+.back-bar-title { font-weight: 600; flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── Buttons ──────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 0.625rem;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.12s, opacity 0.12s;
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+.btn-primary { background: var(--teal); color: #fff; }
+.btn-primary:active { background: var(--teal-d); }
+.btn-lg { width: 100%; padding: 0.8125rem; font-size: 1rem; font-weight: 600; border-radius: 0.875rem; }
+.btn-secondary { background: var(--gray-100); color: var(--gray-700); }
+.btn-secondary:active { background: var(--gray-200); }
+.btn-blue { background: var(--blue); color: #fff; }
+.btn-blue:active { background: var(--blue-d); }
+.btn-ghost { background: none; border: none; cursor: pointer; color: var(--teal); font-weight: 500; font-size: 0.9375rem; padding: 0; }
+.btn-danger-soft {
+  background: var(--red-50); color: var(--red);
+  border: 1px solid var(--red-100); border-radius: 9999px;
+  padding: 0.25rem 0.75rem; font-size: 0.75rem; font-weight: 500;
+}
+.btn-icon { background: none; border: none; cursor: pointer; color: var(--gray-300); font-size: 1.15rem; padding: 0.25rem; line-height: 1; flex-shrink: 0; }
+.btn-icon:active { color: var(--red); }
+.btn-add {
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  border: 1.5px dashed var(--gray-300);
+  border-radius: 0.875rem;
+  background: white;
+  color: var(--gray-500);
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-align: center;
+  display: block;
+}
+
+/* ── Form elements ────────────────────────── */
+.form { display: flex; flex-direction: column; gap: 0.5rem; }
+.input {
+  width: 100%;
+  padding: 0.6875rem 0.875rem;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.625rem;
+  background: white;
+  color: var(--gray-800);
+  font-size: 0.9375rem;
+  outline: none;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.input:focus { border-color: var(--teal); box-shadow: 0 0 0 3px rgba(20,184,166,.15); }
+.input-lg { padding: 0.8125rem; border-radius: 0.875rem; font-size: 1rem; }
+.input-row { display: flex; gap: 0.5rem; }
+.input-row .input { flex: 1; }
+.input-prefix { position: relative; }
+.input-prefix-sym {
+  position: absolute; left: 0.75rem; top: 50%; transform: translateY(-50%);
+  color: var(--gray-400); font-size: 0.875rem; pointer-events: none;
+}
+.input-prefix .input { padding-left: 1.75rem; }
+.field-label { font-size: 0.75rem; font-weight: 500; color: var(--gray-500); margin-bottom: 0.125rem; }
+.field-hint { font-size: 0.75rem; color: var(--gray-400); margin-top: 0.25rem; }
+
+/* ── Cards ────────────────────────────────── */
+.card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.875rem;
+  padding: 1rem;
+  margin-bottom: 0.875rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.04);
+}
+.card-form {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.875rem;
+  padding: 1rem;
+  margin-bottom: 0.875rem;
+}
+.section-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.section-title { font-weight: 600; font-size: 0.9375rem; }
+
+/* ── Trip cards ───────────────────────────── */
+.trip-card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.875rem;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.04);
+  cursor: pointer;
+}
+.trip-card-body { flex: 1; min-width: 0; }
+.trip-card-title { display: flex; align-items: center; gap: 0.375rem; }
+.trip-card-name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.trip-card-desc { font-size: 0.8125rem; color: var(--gray-400); margin-top: 0.125rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.trip-card-meta { font-size: 0.75rem; color: var(--gray-400); margin-top: 0.375rem; }
+
+/* ── Badges & chips ───────────────────────── */
+.badge {
+  display: inline-block;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  flex-shrink: 0;
+  letter-spacing: 0.01em;
+}
+.badge-settled { background: var(--green-100); color: var(--green); }
+.badge-gray { background: var(--gray-100); color: var(--gray-500); }
+.chip-list { display: flex; flex-wrap: wrap; gap: 0.375rem; }
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  background: var(--teal-50);
+  color: var(--teal-700);
+  border: 1px solid var(--teal-100);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+}
+.chip-x {
+  background: none; border: none; cursor: pointer;
+  color: #5eead4; font-size: 1rem; line-height: 1; font-weight: 700; padding: 0; margin-left: 0.125rem;
+}
+.chip-x:active { color: var(--red); }
+.participant-chip {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  background: var(--gray-100);
+  color: var(--gray-600);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+}
+
+/* ── Summary card ─────────────────────────── */
+.summary-card { background: white; border: 1px solid var(--gray-200); border-radius: 0.875rem; padding: 1rem; margin-bottom: 0.875rem; box-shadow: 0 1px 3px rgba(0,0,0,.04); }
+.summary-paid { font-size: 0.9375rem; color: var(--gray-600); }
+.summary-paid b { color: var(--gray-800); }
+.debt-line { font-size: 0.875rem; margin-top: 0.375rem; }
+.debt-owe { color: var(--red); font-weight: 500; }
+.debt-recv { color: var(--green); font-weight: 500; }
+.debt-other { color: var(--gray-500); }
+
+/* ── Transaction cards ────────────────────── */
+.tx-card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.875rem;
+  padding: 0.875rem;
+  margin-bottom: 0.625rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.04);
+}
+.tx-body { flex: 1; min-width: 0; }
+.tx-row { display: flex; justify-content: space-between; align-items: baseline; gap: 0.5rem; }
+.tx-name { font-weight: 500; font-size: 0.9375rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tx-amount { font-weight: 600; font-size: 0.9375rem; color: var(--gray-700); flex-shrink: 0; }
+.tx-payer { font-size: 0.75rem; color: var(--gray-400); margin-top: 0.125rem; }
+.tx-splits { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-top: 0.5rem; }
+.tx-split {
+  font-size: 0.6875rem; padding: 0.125rem 0.5rem;
+  background: var(--gray-100); border-radius: 9999px; color: var(--gray-500);
+}
+
+/* ── Empty state ──────────────────────────── */
+.empty {
+  display: flex; flex-direction: column; align-items: center;
+  justify-content: center; flex: 1; padding: 3rem 0;
+  color: var(--gray-400); text-align: center;
+}
+.empty-icon { font-size: 2.75rem; margin-bottom: 0.75rem; }
+.empty-text { font-size: 0.9375rem; }
+
+/* ── Footer ───────────────────────────────── */
+.footer {
+  margin-top: auto;
+  padding: 2rem 0 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--gray-300);
+}
+
+/* ── Utilities ────────────────────────────── */
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 0.75rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.flex-row { display: flex; align-items: center; gap: 0.5rem; }
+</style>
 </head>
-<body class="bg-gray-50 min-h-screen text-gray-800">
+<body>
+<div id="app" v-cloak>
 
-<div id="app" v-cloak class="max-w-lg mx-auto px-4 pb-10 min-h-screen flex flex-col">
-
-  <!-- ── SETUP VIEW ───────────────────────────────────────────────── -->
-  <div v-if="view === 'setup'" class="flex-1 flex flex-col justify-center py-12">
-    <div class="text-center mb-8">
-      <div class="text-5xl mb-3">🧾</div>
-      <h1 class="text-3xl font-bold text-teal-600">Urunan</h1>
-      <p class="text-gray-400 mt-1">Split bills with friends &amp; family</p>
+  <!-- ── SETUP SCREEN ─────────────────────────────────── -->
+  <div v-if="view === 'setup'" class="setup-screen">
+    <div class="hero">
+      <div class="hero-icon">🧾</div>
+      <h1 class="hero-title">Urunan</h1>
+      <p class="hero-sub">Split bills with friends &amp; family</p>
     </div>
-    <form @submit.prevent="completeSetup" class="space-y-3">
-      <input v-model="setupForm.name" type="text" required placeholder="Your name"
-        class="w-full p-3 border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-teal-400 text-base">
-      <input v-model="setupForm.email" type="email" required placeholder="Your email"
-        class="w-full p-3 border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-teal-400 text-base">
-      <button type="submit"
-        class="w-full p-3 bg-teal-500 hover:bg-teal-600 text-white rounded-xl font-semibold text-base transition-colors">
-        Get Started
-      </button>
+    <form class="form" @submit.prevent="completeSetup">
+      <input v-model="setupForm.name" class="input input-lg" type="text" required placeholder="Your name" autocomplete="name">
+      <input v-model="setupForm.email" class="input input-lg" type="email" required placeholder="your@email.com" autocomplete="email">
+      <button type="submit" class="btn btn-primary btn-lg" style="margin-top:0.25rem">Get Started →</button>
     </form>
-    <p class="text-center text-xs text-gray-400 mt-4">All data is saved locally on this device.</p>
+    <p class="hero-note">All data is saved locally on this device.</p>
   </div>
 
-  <!-- ── TRIP LIST VIEW ────────────────────────────────────────────── -->
-  <div v-else-if="view === 'trips'" class="flex-1 flex flex-col">
-    <!-- Header -->
-    <div class="flex items-center justify-between py-4 border-b border-gray-200 mb-4">
-      <div>
-        <span class="font-semibold">🏕️ {{ currentUser.name }}</span>
-        <span class="text-xs text-gray-400 ml-2">{{ currentUser.email }}</span>
+  <!-- ── TRIP LIST SCREEN ──────────────────────────────── -->
+  <div v-else-if="view === 'trips'" style="flex:1;display:flex;flex-direction:column">
+
+    <!-- Install banner (first time) -->
+    <div v-if="showInstallBanner" class="install-banner" style="margin-top:0.75rem">
+      <span style="font-size:1.5rem;flex-shrink:0">📲</span>
+      <div class="install-banner-text">
+        <b>Add to Home Screen for easy access</b>
+        In Safari, tap the <b>Share</b> button (□↑) then <b>"Add to Home Screen"</b> — Urunan will appear as an app icon you can tap directly.
       </div>
-      <button @click="logout"
-        class="text-sm px-3 py-1 bg-red-50 text-red-500 rounded-full border border-red-100">
-        Logout
-      </button>
+      <button class="install-close" @click="dismissInstallBanner">×</button>
     </div>
 
-    <h2 class="text-lg font-semibold mb-3">Your Trips</h2>
+    <div class="topbar">
+      <div class="topbar-left">
+        <span class="topbar-name">🏕️ { currentUser.name }</span>
+        <span class="topbar-email">{ currentUser.email }</span>
+      </div>
+      <button class="btn-danger-soft" @click="logout">Logout</button>
+    </div>
 
-    <!-- Create Trip Toggle -->
-    <button @click="showAddTrip = !showAddTrip"
-      class="w-full p-3 mb-3 border border-dashed border-gray-300 rounded-xl bg-white text-gray-500 text-sm text-center">
-      {{ showAddTrip ? '✕ Cancel' : '+ Create New Trip' }}
+    <div class="section-row">
+      <span class="section-title">Your Trips</span>
+    </div>
+
+    <!-- Create trip toggle -->
+    <button class="btn-add" @click="showAddTrip = !showAddTrip">
+      { showAddTrip ? '✕ Cancel' : '+ Create New Trip' }
     </button>
 
-    <!-- Create Trip Form -->
-    <div v-if="showAddTrip" class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
-      <form @submit.prevent="createTrip" class="space-y-2">
-        <input v-model="tripForm.title" type="text" required placeholder="Trip name (e.g. Bali 2024)"
-          class="w-full p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
-        <input v-model="tripForm.text" type="text" placeholder="Description (optional)"
-          class="w-full p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
+    <!-- Create trip form -->
+    <div v-if="showAddTrip" class="card-form mb-2">
+      <form class="form" @submit.prevent="createTrip">
+        <input v-model="tripForm.title" class="input" type="text" required placeholder="Trip name (e.g. Bali 2025)">
+        <input v-model="tripForm.text" class="input" type="text" placeholder="Description (optional)">
 
-        <p class="text-xs text-gray-500 pt-1 font-medium">Participants</p>
-        <div class="flex gap-2">
-          <input v-model="tripForm.participantInput" type="email" placeholder="friend@email.com"
-            class="flex-1 p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400"
-            @keydown.enter.prevent="addParticipant">
-          <button type="button" @click="addParticipant"
-            class="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg text-sm text-gray-700 transition-colors">
-            Add
-          </button>
+        <div class="mb-1">
+          <div class="field-label" style="margin-bottom:0.375rem">Invite Participants</div>
+          <div class="input-row">
+            <input v-model="tripForm.participantInput" class="input" type="email" placeholder="friend@email.com"
+              @keydown.enter.prevent="addParticipant">
+            <button type="button" class="btn btn-secondary" @click="addParticipant" style="flex-shrink:0">Add</button>
+          </div>
         </div>
 
-        <div v-if="tripForm.participants.length" class="flex flex-wrap gap-2">
-          <span v-for="p in tripForm.participants" :key="p.email"
-            class="flex items-center gap-1 px-2.5 py-1 bg-teal-50 text-teal-700 rounded-full text-xs border border-teal-100">
-            {{ p.email }}
-            <button type="button" @click="removeParticipant(p.email)"
-              class="ml-0.5 text-teal-400 hover:text-red-400 font-bold leading-none">×</button>
+        <div v-if="tripForm.participants.length" class="chip-list mb-1">
+          <span v-for="p in tripForm.participants" :key="p.email" class="chip">
+            { p.email }
+            <button type="button" class="chip-x" @click="removeParticipant(p.email)">×</button>
           </span>
         </div>
-        <p class="text-xs text-gray-400">You ({{ currentUser.email }}) are included automatically.</p>
+        <div class="field-hint" style="margin-top:-0.125rem">You ({ currentUser.email }) are included automatically.</div>
 
-        <button type="submit"
-          class="w-full p-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium transition-colors mt-1">
-          Save Trip
-        </button>
+        <button type="submit" class="btn btn-primary btn-lg" style="margin-top:0.375rem">Save Trip</button>
       </form>
     </div>
 
-    <!-- Trip Cards -->
-    <div v-if="myTrips.length === 0 && !showAddTrip"
-      class="flex-1 flex flex-col items-center justify-center text-gray-400 py-16">
-      <div class="text-4xl mb-3">🧳</div>
-      <p class="text-sm">No trips yet. Create one above!</p>
+    <!-- Trip list -->
+    <div v-if="myTrips.length === 0 && !showAddTrip" class="empty" style="flex:1">
+      <div class="empty-icon">🧳</div>
+      <div class="empty-text">No trips yet.<br>Create one above!</div>
     </div>
 
-    <div v-for="trip in myTrips" :key="trip.id"
-      class="bg-white border border-gray-200 rounded-xl p-4 mb-3 shadow-sm">
-      <div class="flex items-start gap-3">
-        <div @click="openTrip(trip.id)" class="flex-1 cursor-pointer min-w-0">
-          <div class="flex items-center gap-2">
-            <h3 class="font-semibold text-gray-800 truncate">{{ trip.title }}</h3>
-            <span v-if="trip.is_resolved"
-              class="shrink-0 text-xs px-2 py-0.5 bg-green-100 text-green-600 rounded-full">Settled</span>
-          </div>
-          <p v-if="trip.text" class="text-sm text-gray-400 mt-0.5 truncate">{{ trip.text }}</p>
-          <p class="text-xs text-gray-400 mt-1.5">
-            👥 {{ trip.users.length }} · 💳 {{ trip.transactions.length }} transactions
-            · Total €{{ tripTotal(trip).toFixed(2) }}
-          </p>
+    <div v-for="trip in myTrips" :key="trip.id" class="trip-card">
+      <div class="trip-card-body" @click="openTrip(trip.id)">
+        <div class="trip-card-title">
+          <span class="trip-card-name">{ trip.title }</span>
+          <span v-if="trip.is_resolved" class="badge badge-settled">Settled</span>
         </div>
-        <button @click="confirmDeleteTrip(trip.id)"
-          class="shrink-0 text-gray-300 hover:text-red-400 transition-colors p-1 text-lg leading-none">
-          🗑
-        </button>
+        <div v-if="trip.text" class="trip-card-desc">{ trip.text }</div>
+        <div class="trip-card-meta">
+          👥 { trip.users.length } · 💳 { trip.transactions.length } txn · €{ tripTotal(trip).toFixed(2) }
+        </div>
       </div>
+      <button class="btn-icon" @click="confirmDeleteTrip(trip.id)">🗑</button>
     </div>
   </div>
 
-  <!-- ── TRIP DETAIL VIEW ──────────────────────────────────────────── -->
-  <div v-else-if="view === 'trip-detail' && currentTrip" class="flex-1 flex flex-col">
-    <!-- Back bar -->
-    <div class="flex items-center gap-3 py-4 border-b border-gray-200 mb-4">
-      <button @click="view = 'trips'" class="text-teal-500 font-medium">← Back</button>
-      <h2 class="font-semibold flex-1 truncate">{{ currentTrip.title }}</h2>
-      <span v-if="currentTrip.is_resolved"
-        class="shrink-0 text-xs px-2 py-1 bg-green-100 text-green-600 rounded-full">Settled</span>
+  <!-- ── TRIP DETAIL SCREEN ────────────────────────────── -->
+  <div v-else-if="view === 'trip-detail' && currentTrip" style="flex:1;display:flex;flex-direction:column">
+
+    <div class="back-bar">
+      <button class="btn-ghost" @click="view = 'trips'">← Back</button>
+      <span class="back-bar-title">{ currentTrip.title }</span>
+      <span v-if="currentTrip.is_resolved" class="badge badge-settled">Settled</span>
     </div>
 
-    <!-- Debt Summary Card -->
-    <div class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
-      <h3 class="font-semibold mb-2 text-base">💰 Summary</h3>
-      <p class="text-sm text-gray-600">
-        You paid: <span class="font-semibold text-gray-800">€{{ myPaid.toFixed(2) }}</span>
-      </p>
-
-      <div v-if="mappedDebt.length === 0" class="text-sm text-gray-400 mt-2">
-        {{ currentTrip.transactions.length === 0 ? 'No transactions yet.' : 'All settled up! 🎉' }}
+    <!-- Debt Summary -->
+    <div class="summary-card">
+      <div class="section-title" style="margin-bottom:0.5rem">💰 Summary</div>
+      <div class="summary-paid">You paid: <b>€{ myPaid.toFixed(2) }</b></div>
+      <div v-if="mappedDebt.length === 0" class="debt-line" style="color:var(--gray-400)">
+        { currentTrip.transactions.length === 0 ? 'No transactions yet.' : 'All settled up! 🎉' }
       </div>
-
-      <div v-for="debt in mappedDebt" :key="debt.from_user.email + '>' + debt.to_user.email"
-        class="mt-1.5 text-sm">
-        <span v-if="debt.from_user.email === currentUser.email" class="text-red-500 font-medium">
-          ↑ You owe {{ debt.to_user.email }}: €{{ debt.amount.toFixed(2) }}
+      <div v-for="d in mappedDebt" :key="d.from_user.email + d.to_user.email" class="debt-line">
+        <span v-if="d.from_user.email === currentUser.email" class="debt-owe">
+          ↑ You owe { d.to_user.email }: €{ d.amount.toFixed(2) }
         </span>
-        <span v-else-if="debt.to_user.email === currentUser.email" class="text-green-600 font-medium">
-          ↓ {{ debt.from_user.email }} owes you: €{{ debt.amount.toFixed(2) }}
+        <span v-else-if="d.to_user.email === currentUser.email" class="debt-recv">
+          ↓ { d.from_user.email } owes you: €{ d.amount.toFixed(2) }
         </span>
-        <span v-else class="text-gray-500">
-          {{ debt.from_user.email }} → {{ debt.to_user.email }}: €{{ debt.amount.toFixed(2) }}
+        <span v-else class="debt-other">
+          { d.from_user.email } → { d.to_user.email }: €{ d.amount.toFixed(2) }
         </span>
       </div>
-
       <button v-if="!currentTrip.is_resolved && currentTrip.transactions.length > 0"
-        @click="settleTrip"
-        class="mt-3 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-sm font-medium transition-colors">
+        class="btn btn-blue mt-3" @click="settleTrip">
         ✓ Settle Trip
       </button>
     </div>
 
     <!-- Participants -->
-    <div class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
-      <h3 class="font-semibold mb-2 text-sm">👥 Participants ({{ currentTrip.users.length }})</h3>
-      <div class="flex flex-wrap gap-2">
-        <span v-for="u in currentTrip.users" :key="u.email"
-          class="text-xs px-2.5 py-1 bg-gray-100 text-gray-600 rounded-full">
-          {{ u.email }}
-        </span>
+    <div class="card" style="margin-bottom:0.875rem">
+      <div class="section-title mb-2">👥 Participants</div>
+      <div class="chip-list">
+        <span v-for="u in currentTrip.users" :key="u.email" class="participant-chip">{ u.email }</span>
       </div>
     </div>
 
-    <!-- Transactions Section -->
-    <div v-if="!currentTrip.is_resolved">
-      <div class="flex items-center justify-between mb-2">
-        <h3 class="font-semibold">🥤 Transactions</h3>
-        <span class="text-xs text-gray-400">Total €{{ tripTotal(currentTrip).toFixed(2) }}</span>
-      </div>
-
-      <button @click="showAddTransaction = !showAddTransaction"
-        class="w-full p-3 mb-3 border border-dashed border-gray-300 rounded-xl bg-white text-gray-500 text-sm text-center">
-        {{ showAddTransaction ? '✕ Cancel' : '+ Add Transaction' }}
-      </button>
-
-      <!-- Add Transaction Form -->
-      <div v-if="showAddTransaction" class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
-        <form @submit.prevent="addTransaction" class="space-y-2">
-          <select v-model="transactionForm.email" required
-            class="w-full p-2.5 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-400">
-            <option value="" disabled>-- Who paid? --</option>
-            <option v-for="u in currentTrip.users" :key="u.email" :value="u.email">
-              {{ u.email }}
-            </option>
-          </select>
-          <input v-model="transactionForm.title" type="text" required placeholder="What was it for?"
-            class="w-full p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
-          <div class="relative">
-            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm pointer-events-none">€</span>
-            <input v-model.number="transactionForm.cost" type="number" min="0.01" step="any" required placeholder="0.00"
-              class="w-full pl-7 p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
-          </div>
-          <p class="text-xs text-gray-400">Split equally: €{{ perPersonCost }} per person</p>
-          <button type="submit"
-            class="w-full p-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium transition-colors">
-            Add Transaction
-          </button>
-        </form>
-      </div>
+    <!-- Transactions header -->
+    <div class="section-row">
+      <span class="section-title">🥤 Transactions</span>
+      <span style="font-size:0.8125rem;color:var(--gray-400)">Total €{ tripTotal(currentTrip).toFixed(2) }</span>
     </div>
 
-    <!-- Transaction List -->
-    <div v-if="currentTrip.is_resolved" class="mb-2">
-      <h3 class="font-semibold mb-2">🥤 Transactions</h3>
-    </div>
+    <!-- Add transaction toggle (only if not settled) -->
+    <button v-if="!currentTrip.is_resolved" class="btn-add" @click="showAddTransaction = !showAddTransaction">
+      { showAddTransaction ? '✕ Cancel' : '+ Add Transaction' }
+    </button>
 
-    <div v-if="currentTrip.transactions.length === 0" class="text-center text-gray-400 py-8 text-sm">
-      No transactions yet.
-    </div>
-
-    <div v-for="tx in [...currentTrip.transactions].reverse()" :key="tx.id"
-      class="bg-white border border-gray-200 rounded-xl p-3.5 mb-2.5 shadow-sm">
-      <div class="flex items-start gap-2">
-        <div class="flex-1 min-w-0">
-          <div class="flex items-center justify-between gap-2">
-            <p class="font-medium text-sm truncate">{{ tx.title }}</p>
-            <span class="shrink-0 font-semibold text-sm text-gray-700">€{{ tx.cost.toFixed(2) }}</span>
-          </div>
-          <p class="text-xs text-gray-400 mt-0.5">Paid by {{ tx.email }}</p>
-          <div class="mt-1.5 flex flex-wrap gap-1">
-            <span v-for="d in tx.details" :key="d.email"
-              class="text-xs px-2 py-0.5 bg-gray-100 rounded-full text-gray-500">
-              {{ d.email.split('@')[0] }}: €{{ d.cost.toFixed(2) }}
-            </span>
-          </div>
+    <!-- Add transaction form -->
+    <div v-if="showAddTransaction && !currentTrip.is_resolved" class="card-form">
+      <form class="form" @submit.prevent="addTransaction">
+        <select v-model="transactionForm.email" class="input" required>
+          <option value="" disabled>-- Who paid? --</option>
+          <option v-for="u in currentTrip.users" :key="u.email" :value="u.email">{ u.email }</option>
+        </select>
+        <input v-model="transactionForm.title" class="input" type="text" required placeholder="What was it for?">
+        <div class="input-prefix">
+          <span class="input-prefix-sym">€</span>
+          <input v-model.number="transactionForm.cost" class="input" type="number" min="0.01" step="any" required placeholder="0.00">
         </div>
-        <button v-if="!currentTrip.is_resolved" @click="confirmDeleteTransaction(tx.id)"
-          class="shrink-0 text-gray-300 hover:text-red-400 transition-colors p-1 text-lg leading-none">
-          🗑
-        </button>
-      </div>
+        <div class="field-hint">Split equally: €{ perPersonCost } per person ({ currentTrip.users.length } people)</div>
+        <button type="submit" class="btn btn-primary btn-lg" style="margin-top:0.25rem">Add Transaction</button>
+      </form>
     </div>
+
+    <!-- Transaction list (newest first) -->
+    <div v-if="currentTrip.transactions.length === 0" class="empty" style="padding:2rem 0">
+      <div class="empty-icon">🧾</div>
+      <div class="empty-text">No transactions yet.</div>
+    </div>
+
+    <div v-for="tx in [...currentTrip.transactions].reverse()" :key="tx.id" class="tx-card">
+      <div class="tx-body">
+        <div class="tx-row">
+          <span class="tx-name">{ tx.title }</span>
+          <span class="tx-amount">€{ tx.cost.toFixed(2) }</span>
+        </div>
+        <div class="tx-payer">Paid by { tx.email }</div>
+        <div class="tx-splits">
+          <span v-for="d in tx.details" :key="d.email" class="tx-split">
+            { d.email.split('@')[0] }: €{ d.cost.toFixed(2) }
+          </span>
+        </div>
+      </div>
+      <button v-if="!currentTrip.is_resolved" class="btn-icon" @click="confirmDeleteTransaction(tx.id)">🗑</button>
+    </div>
+
   </div>
 
-  <!-- Footer -->
-  <footer class="pt-8 pb-2 text-center text-xs text-gray-300">
-    Urunan © 2024 · Data stored locally on this device
-  </footer>
+  <div class="footer">Urunan · Data saved on this device</div>
 </div>
 
+<script>
+/**
+* vue v3.5.39
+* (c) 2018-present Yuxi (Evan) You and Vue contributors
+* @license MIT
+**/var Vue=function(e){"use strict";var t,n,r;let i,l,s,o,a,c,u,d,h,p,f,g,m;function y(e){let t=Object.create(null);for(let n of e.split(","))t[n]=1;return e=>e in t}let b={},_=[],S=()=>{},x=()=>!1,C=e=>111===e.charCodeAt(0)&&110===e.charCodeAt(1)&&(e.charCodeAt(2)>122||97>e.charCodeAt(2)),k=e=>e.startsWith("onUpdate:"),T=Object.assign,w=(e,t)=>{let n=e.indexOf(t);n>-1&&e.splice(n,1)},N=Object.prototype.hasOwnProperty,A=(e,t)=>N.call(e,t),E=Array.isArray,I=e=>"function"==typeof e,R=e=>"string"==typeof e,O=e=>"symbol"==typeof e,M=e=>null!==e&&"object"==typeof e,P=e=>(M(e)||I(e))&&I(e.then)&&I(e.catch),F=Object.prototype.toString,L=e=>R(e)&&"NaN"!==e&&"-"!==e[0]&&""+parseInt(e,10)===e,$=y(",key,ref,ref_for,ref_key,onVnodeBeforeMount,onVnodeMounted,onVnodeBeforeUpdate,onVnodeUpdated,onVnodeBeforeUnmount,onVnodeUnmounted"),D=y("bind,cloak,else-if,else,for,html,if,model,on,once,pre,show,slot,text,memo"),V=e=>{let t=Object.create(null);return n=>t[n]||(t[n]=e(n))},B=/-\w/g,j=V(e=>e.replace(B,e=>e.slice(1).toUpperCase())),U=/\B([A-Z])/g,H=V(e=>e.replace(U,"-$1").toLowerCase()),q=V(e=>e.charAt(0).toUpperCase()+e.slice(1)),W=V(e=>e?`on${q(e)}`:""),K=(e,t)=>!Object.is(e,t),z=(e,...t)=>{for(let n=0;n<e.length;n++)e[n](...t)},J=(e,t,n,r=!1)=>{Object.defineProperty(e,t,{configurable:!0,enumerable:!1,writable:r,value:n})},G=e=>{let t=parseFloat(e);return isNaN(t)?e:t},X=e=>{let t=R(e)?Number(e):NaN;return isNaN(t)?e:t},Q=()=>i||(i="u">typeof globalThis?globalThis:"u">typeof self?self:"u">typeof window?window:"u">typeof global?global:{}),Z=y("Infinity,undefined,NaN,isFinite,isNaN,parseFloat,parseInt,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,Math,Number,Date,Array,Object,Boolean,String,RegExp,Map,Set,JSON,Intl,BigInt,console,Error,Symbol");function Y(e){if(E(e)){let t={};for(let n=0;n<e.length;n++){let r=e[n],i=R(r)?er(r):Y(r);if(i)for(let e in i)t[e]=i[e]}return t}if(R(e)||M(e))return e}let ee=/;(?![^(]*\))/g,et=/:([^]+)/,en=/\/\*[^]*?\*\//g;function er(e){let t={};return e.replace(en,"").split(ee).forEach(e=>{if(e){let n=e.split(et);n.length>1&&(t[n[0].trim()]=n[1].trim())}}),t}function ei(e){let t="";if(R(e))t=e;else if(E(e))for(let n=0;n<e.length;n++){let r=ei(e[n]);r&&(t+=r+" ")}else if(M(e))for(let n in e)e[n]&&(t+=n+" ");return t.trim()}let el=y("html,body,base,head,link,meta,style,title,address,article,aside,footer,header,hgroup,h1,h2,h3,h4,h5,h6,nav,section,div,dd,dl,dt,figcaption,figure,picture,hr,img,li,main,ol,p,pre,ul,a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,ruby,s,samp,small,span,strong,sub,sup,time,u,var,wbr,area,audio,map,track,video,embed,object,param,source,canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,option,output,progress,select,textarea,details,dialog,menu,summary,template,blockquote,iframe,tfoot"),es=y("svg,animate,animateMotion,animateTransform,circle,clipPath,color-profile,defs,desc,discard,ellipse,feBlend,feColorMatrix,feComponentTransfer,feComposite,feConvolveMatrix,feDiffuseLighting,feDisplacementMap,feDistantLight,feDropShadow,feFlood,feFuncA,feFuncB,feFuncG,feFuncR,feGaussianBlur,feImage,feMerge,feMergeNode,feMorphology,feOffset,fePointLight,feSpecularLighting,feSpotLight,feTile,feTurbulence,filter,foreignObject,g,hatch,hatchpath,image,line,linearGradient,marker,mask,mesh,meshgradient,meshpatch,meshrow,metadata,mpath,path,pattern,polygon,polyline,radialGradient,rect,set,solidcolor,stop,switch,symbol,text,textPath,title,tspan,unknown,use,view"),eo=y("annotation,annotation-xml,maction,maligngroup,malignmark,math,menclose,merror,mfenced,mfrac,mfraction,mglyph,mi,mlabeledtr,mlongdiv,mmultiscripts,mn,mo,mover,mpadded,mphantom,mprescripts,mroot,mrow,ms,mscarries,mscarry,msgroup,msline,mspace,msqrt,msrow,mstack,mstyle,msub,msubsup,msup,mtable,mtd,mtext,mtr,munder,munderover,none,semantics"),ea=y("area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr"),ec=y("itemscope,allowfullscreen,formnovalidate,ismap,nomodule,novalidate,readonly");function eu(e,t){let n,r;if(e===t)return!0;let i="[object Date]"===(n=e,F.call(n)),l="[object Date]"===(r=t,F.call(r));if(i||l)return!!i&&!!l&&e.getTime()===t.getTime();if(i=O(e),l=O(t),i||l)return e===t;if(i=E(e),l=E(t),i||l)return!!i&&!!l&&function(e,t){if(e.length!==t.length)return!1;let n=!0;for(let r=0;n&&r<e.length;r++)n=eu(e[r],t[r]);return n}(e,t);if(i=M(e),l=M(t),i||l){if(!i||!l||Object.keys(e).length!==Object.keys(t).length)return!1;for(let n in e){let r=e.hasOwnProperty(n),i=t.hasOwnProperty(n);if(r&&!i||!r&&i||!eu(e[n],t[n]))return!1}}return String(e)===String(t)}function ed(e,t){return e.findIndex(e=>eu(e,t))}let eh=e=>!!(e&&!0===e.__v_isRef),ep=e=>R(e)?e:null==e?"":E(e)||M(e)&&(e.toString===F||!I(e.toString))?eh(e)?ep(e.value):JSON.stringify(e,ef,2):String(e),ef=(e,t)=>{let n;if(eh(t))return ef(e,t.value);if("[object Map]"===(n=t,F.call(n)))return{[`Map(${t.size})`]:[...t.entries()].reduce((e,[t,n],r)=>(e[eg(t,r)+" =>"]=n,e),{})};{let e;if("[object Set]"===(e=t,F.call(e)))return{[`Set(${t.size})`]:[...t.values()].map(e=>eg(e))};else{if(O(t))return eg(t);let e;if(M(t)&&!E(t)&&"[object Object]"!==(e=t,F.call(e)))return String(t)}}return t},eg=(e,t="")=>{var n;return O(e)?`Symbol(${null!=(n=e.description)?n:t})`:e};class em{constructor(e=!1){this.detached=e,this._active=!0,this._on=0,this.effects=[],this.cleanups=[],this._isPaused=!1,this._warnOnRun=!0,this.__v_skip=!0,!e&&l&&(l.active?(this.parent=l,this.index=(l.scopes||(l.scopes=[])).push(this)-1):(this._active=!1,this._warnOnRun=!1))}get active(){return this._active}pause(){if(this._active){let e,t;if(this._isPaused=!0,this.scopes)for(e=0,t=this.scopes.length;e<t;e++)this.scopes[e].pause();for(e=0,t=this.effects.length;e<t;e++)this.effects[e].pause()}}resume(){if(this._active&&this._isPaused){let e,t;if(this._isPaused=!1,this.scopes)for(e=0,t=this.scopes.length;e<t;e++)this.scopes[e].resume();for(e=0,t=this.effects.length;e<t;e++)this.effects[e].resume()}}run(e){if(this._active){let t=l;try{return l=this,e()}finally{l=t}}}on(){1==++this._on&&(this.prevScope=l,l=this)}off(){if(this._on>0&&0==--this._on){if(l===this)l=this.prevScope;else{let e=l;for(;e;){if(e.prevScope===this){e.prevScope=this.prevScope;break}e=e.prevScope}}this.prevScope=void 0}}stop(e){if(this._active){let t,n;for(this._active=!1,t=0,n=this.effects.length;t<n;t++)this.effects[t].stop();for(this.effects.length=0,t=0,n=this.cleanups.length;t<n;t++)this.cleanups[t]();if(this.cleanups.length=0,this.scopes){for(t=0,n=this.scopes.length;t<n;t++)this.scopes[t].stop(!0);this.scopes.length=0}if(!this.detached&&this.parent&&!e){let e=this.parent.scopes.pop();e&&e!==this&&(this.parent.scopes[this.index]=e,e.index=this.index)}this.parent=void 0}}}let ev=new WeakSet;class ey{constructor(e){this.fn=e,this.deps=void 0,this.depsTail=void 0,this.flags=5,this.next=void 0,this.cleanup=void 0,this.scheduler=void 0,l&&(l.active?l.effects.push(this):this.flags&=-2)}pause(){this.flags|=64}resume(){64&this.flags&&(this.flags&=-65,ev.has(this)&&(ev.delete(this),this.trigger()))}notify(){(!(2&this.flags)||32&this.flags)&&(8&this.flags||e_(this))}run(){if(!(1&this.flags))return this.fn();this.flags|=2,eR(this),ex(this);let e=s,t=eN;s=this,eN=!0;try{return this.fn()}finally{eC(this),s=e,eN=t,this.flags&=-3}}stop(){if(1&this.flags){for(let e=this.deps;e;e=e.nextDep)ew(e);this.deps=this.depsTail=void 0,eR(this),this.onStop&&this.onStop(),this.flags&=-2}}trigger(){64&this.flags?ev.add(this):this.scheduler?this.scheduler():this.runIfDirty()}runIfDirty(){ek(this)&&this.run()}get dirty(){return ek(this)}}let eb=0;function e_(e,t=!1){if(e.flags|=8,t){e.next=a,a=e;return}e.next=o,o=e}function eS(){let e;if(!(--eb>0)){if(a){let e=a;for(a=void 0;e;){let t=e.next;e.next=void 0,e.flags&=-9,e=t}}for(;o;){let t=o;for(o=void 0;t;){let n=t.next;if(t.next=void 0,t.flags&=-9,1&t.flags)try{t.trigger()}catch(t){e||(e=t)}t=n}}if(e)throw e}}function ex(e){for(let t=e.deps;t;t=t.nextDep)t.version=-1,t.prevActiveLink=t.dep.activeLink,t.dep.activeLink=t}function eC(e){let t,n=e.depsTail,r=n;for(;r;){let e=r.prevDep;-1===r.version?(r===n&&(n=e),ew(r),function(e){let{prevDep:t,nextDep:n}=e;t&&(t.nextDep=n,e.prevDep=void 0),n&&(n.prevDep=t,e.nextDep=void 0)}(r)):t=r,r.dep.activeLink=r.prevActiveLink,r.prevActiveLink=void 0,r=e}e.deps=t,e.depsTail=n}function ek(e){for(let t=e.deps;t;t=t.nextDep)if(t.dep.version!==t.version||t.dep.computed&&(eT(t.dep.computed)||t.dep.version!==t.version))return!0;return!!e._dirty}function eT(e){if(4&e.flags&&!(16&e.flags)||(e.flags&=-17,e.globalVersion===eO)||(e.globalVersion=eO,!e.isSSR&&128&e.flags&&(!e.deps&&!e._dirty||!ek(e))))return;e.flags|=2;let t=e.dep,n=s,r=eN;s=e,eN=!0;try{ex(e);let n=e.fn(e._value);(0===t.version||K(n,e._value))&&(e.flags|=128,e._value=n,t.version++)}catch(e){throw t.version++,e}finally{s=n,eN=r,eC(e),e.flags&=-3}}function ew(e,t=!1){let{dep:n,prevSub:r,nextSub:i}=e;if(r&&(r.nextSub=i,e.prevSub=void 0),i&&(i.prevSub=r,e.nextSub=void 0),n.subs===e&&(n.subs=r,!r&&n.computed)){n.computed.flags&=-5;for(let e=n.computed.deps;e;e=e.nextDep)ew(e,!0)}t||--n.sc||!n.map||n.map.delete(n.key)}let eN=!0,eA=[];function eE(){eA.push(eN),eN=!1}function eI(){let e=eA.pop();eN=void 0===e||e}function eR(e){let{cleanup:t}=e;if(e.cleanup=void 0,t){let e=s;s=void 0;try{t()}finally{s=e}}}let eO=0;class eM{constructor(e,t){this.sub=e,this.dep=t,this.version=t.version,this.nextDep=this.prevDep=this.nextSub=this.prevSub=this.prevActiveLink=void 0}}class eP{constructor(e){this.computed=e,this.version=0,this.activeLink=void 0,this.subs=void 0,this.map=void 0,this.key=void 0,this.sc=0,this.__v_skip=!0}track(e){if(!s||!eN||s===this.computed)return;let t=this.activeLink;if(void 0===t||t.sub!==s)t=this.activeLink=new eM(s,this),s.deps?(t.prevDep=s.depsTail,s.depsTail.nextDep=t,s.depsTail=t):s.deps=s.depsTail=t,function e(t){if(t.dep.sc++,4&t.sub.flags){let n=t.dep.computed;if(n&&!t.dep.subs){n.flags|=20;for(let t=n.deps;t;t=t.nextDep)e(t)}let r=t.dep.subs;r!==t&&(t.prevSub=r,r&&(r.nextSub=t)),t.dep.subs=t}}(t);else if(-1===t.version&&(t.version=this.version,t.nextDep)){let e=t.nextDep;e.prevDep=t.prevDep,t.prevDep&&(t.prevDep.nextDep=e),t.prevDep=s.depsTail,t.nextDep=void 0,s.depsTail.nextDep=t,s.depsTail=t,s.deps===t&&(s.deps=e)}return t}trigger(e){this.version++,eO++,this.notify(e)}notify(e){eb++;try{for(let e=this.subs;e;e=e.prevSub)e.sub.notify()&&e.sub.dep.notify()}finally{eS()}}}let eF=new WeakMap,eL=Symbol(""),e$=Symbol(""),eD=Symbol("");function eV(e,t,n){if(eN&&s){let t=eF.get(e);t||eF.set(e,t=new Map);let r=t.get(n);r||(t.set(n,r=new eP),r.map=t,r.key=n),r.track()}}function eB(e,t,n,r,i,l){let s=eF.get(e);if(!s)return void eO++;let o=e=>{e&&e.trigger()};if(eb++,"clear"===t)s.forEach(o);else{let i=E(e),l=i&&L(n);if(i&&"length"===n){let e=Number(r);s.forEach((t,n)=>{("length"===n||n===eD||!O(n)&&n>=e)&&o(t)})}else switch((void 0!==n||s.has(void 0))&&o(s.get(n)),l&&o(s.get(eD)),t){case"add":if(i)l&&o(s.get("length"));else{let t;o(s.get(eL));"[object Map]"===(t=e,F.call(t))&&o(s.get(e$))}break;case"delete":if(!i){let t;o(s.get(eL));"[object Map]"===(t=e,F.call(t))&&o(s.get(e$))}break;case"set":let a;"[object Map]"===(a=e,F.call(a))&&o(s.get(eL))}}eS()}function ej(e){let t=tm(e);return t===e?t:(eV(t,"iterate",eD),tf(e)?t:t.map(ty))}function eU(e){return eV(e=tm(e),"iterate",eD),e}function eH(e,t){return tp(e)?th(e)?tb(ty(t)):tb(t):ty(t)}let eq={__proto__:null,[Symbol.iterator](){return eW(this,Symbol.iterator,e=>eH(this,e))},concat(...e){return ej(this).concat(...e.map(e=>E(e)?ej(e):e))},entries(){return eW(this,"entries",e=>(e[1]=eH(this,e[1]),e))},every(e,t){return ez(this,"every",e,t,void 0,arguments)},filter(e,t){return ez(this,"filter",e,t,e=>e.map(e=>eH(this,e)),arguments)},find(e,t){return ez(this,"find",e,t,e=>eH(this,e),arguments)},findIndex(e,t){return ez(this,"findIndex",e,t,void 0,arguments)},findLast(e,t){return ez(this,"findLast",e,t,e=>eH(this,e),arguments)},findLastIndex(e,t){return ez(this,"findLastIndex",e,t,void 0,arguments)},forEach(e,t){return ez(this,"forEach",e,t,void 0,arguments)},includes(...e){return eG(this,"includes",e)},indexOf(...e){return eG(this,"indexOf",e)},join(e){return ej(this).join(e)},lastIndexOf(...e){return eG(this,"lastIndexOf",e)},map(e,t){return ez(this,"map",e,t,void 0,arguments)},pop(){return eX(this,"pop")},push(...e){return eX(this,"push",e)},reduce(e,...t){return eJ(this,"reduce",e,t)},reduceRight(e,...t){return eJ(this,"reduceRight",e,t)},shift(){return eX(this,"shift")},some(e,t){return ez(this,"some",e,t,void 0,arguments)},splice(...e){return eX(this,"splice",e)},toReversed(){return ej(this).toReversed()},toSorted(e){return ej(this).toSorted(e)},toSpliced(...e){return ej(this).toSpliced(...e)},unshift(...e){return eX(this,"unshift",e)},values(){return eW(this,"values",e=>eH(this,e))}};function eW(e,t,n){let r=eU(e),i=r[t]();return r===e||tf(e)||(i._next=i.next,i.next=()=>{let e=i._next();return e.done||(e.value=n(e.value)),e}),i}let eK=Array.prototype;function ez(e,t,n,r,i,l){let s=eU(e),o=s!==e&&!tf(e),a=s[t];if(a!==eK[t]){let t=a.apply(e,l);return o?ty(t):t}let c=n;s!==e&&(o?c=function(t,r){return n.call(this,eH(e,t),r,e)}:n.length>2&&(c=function(t,r){return n.call(this,t,r,e)}));let u=a.call(s,c,r);return o&&i?i(u):u}function eJ(e,t,n,r){let i=eU(e),l=i!==e&&!tf(e),s=n,o=!1;i!==e&&(l?(o=0===r.length,s=function(t,r,i){return o&&(o=!1,t=eH(e,t)),n.call(this,t,eH(e,r),i,e)}):n.length>3&&(s=function(t,r,i){return n.call(this,t,r,i,e)}));let a=i[t](s,...r);return o?eH(e,a):a}function eG(e,t,n){let r=tm(e);eV(r,"iterate",eD);let i=r[t](...n);return(-1===i||!1===i)&&tg(n[0])?(n[0]=tm(n[0]),r[t](...n)):i}function eX(e,t,n=[]){eE(),eb++;let r=tm(e)[t].apply(e,n);return eS(),eI(),r}let eQ=y("__proto__,__v_isRef,__isVue"),eZ=new Set(Object.getOwnPropertyNames(Symbol).filter(e=>"arguments"!==e&&"caller"!==e).map(e=>Symbol[e]).filter(O));function eY(e){O(e)||(e=String(e));let t=tm(this);return eV(t,"has",e),t.hasOwnProperty(e)}class e0{constructor(e=!1,t=!1){this._isReadonly=e,this._isShallow=t}get(e,t,n){if("__v_skip"===t)return e.__v_skip;let r=this._isReadonly,i=this._isShallow;if("__v_isReactive"===t)return!r;if("__v_isReadonly"===t)return r;if("__v_isShallow"===t)return i;if("__v_raw"===t)return n===(r?i?to:ts:i?tl:ti).get(e)||Object.getPrototypeOf(e)===Object.getPrototypeOf(n)?e:void 0;let l=E(e);if(!r){let e;if(l&&(e=eq[t]))return e;if("hasOwnProperty"===t)return eY}let s=Reflect.get(e,t,t_(e)?e:n);if((O(t)?eZ.has(t):eQ(t))||(r||eV(e,"get",t),i))return s;if(t_(s)){let e=l&&L(t)?s:s.value;return r&&M(e)?tu(e):e}return M(s)?r?tu(s):ta(s):s}}class e1 extends e0{constructor(e=!1){super(!1,e)}set(e,t,n,r){let i=e[t],l=E(e)&&L(t);if(!this._isShallow){let e=tp(i);if(tf(n)||tp(n)||(i=tm(i),n=tm(n)),!l&&t_(i)&&!t_(n))if(e)return!0;else return i.value=n,!0}let s=l?Number(t)<e.length:A(e,t),o=Reflect.set(e,t,n,t_(e)?e:r);return e===tm(r)&&o&&(s?K(n,i)&&eB(e,"set",t,n):eB(e,"add",t,n)),o}deleteProperty(e,t){let n=A(e,t);e[t];let r=Reflect.deleteProperty(e,t);return r&&n&&eB(e,"delete",t,void 0),r}has(e,t){let n=Reflect.has(e,t);return O(t)&&eZ.has(t)||eV(e,"has",t),n}ownKeys(e){return eV(e,"iterate",E(e)?"length":eL),Reflect.ownKeys(e)}}class e2 extends e0{constructor(e=!1){super(!0,e)}set(e,t){return!0}deleteProperty(e,t){return!0}}let e6=new e1,e3=new e2,e4=new e1(!0),e8=new e2(!0),e5=e=>e;function e9(e){return function(){return"delete"!==e&&("clear"===e?void 0:this)}}function e7(e,t){let n,r=(T(n={get(n){let r=this.__v_raw,i=tm(r),l=tm(n);e||(K(n,l)&&eV(i,"get",n),eV(i,"get",l));let{has:s}=Reflect.getPrototypeOf(i),o=t?e5:e?tb:ty;return s.call(i,n)?o(r.get(n)):s.call(i,l)?o(r.get(l)):void(r!==i&&r.get(n))},get size(){let t=this.__v_raw;return e||eV(tm(t),"iterate",eL),t.size},has(t){let n=this.__v_raw,r=tm(n),i=tm(t);return e||(K(t,i)&&eV(r,"has",t),eV(r,"has",i)),t===i?n.has(t):n.has(t)||n.has(i)},forEach(n,r){let i=this,l=i.__v_raw,s=tm(l),o=t?e5:e?tb:ty;return e||eV(s,"iterate",eL),l.forEach((e,t)=>n.call(r,o(e),o(t),i))}},e?{add:e9("add"),set:e9("set"),delete:e9("delete"),clear:e9("clear")}:{add(e){let n=tm(this),r=Reflect.getPrototypeOf(n),i=tm(e),l=t||tf(e)||tp(e)?e:i;return r.has.call(n,l)||K(e,l)&&r.has.call(n,e)||K(i,l)&&r.has.call(n,i)||(n.add(l),eB(n,"add",l,l)),this},set(e,n){t||tf(n)||tp(n)||(n=tm(n));let r=tm(this),{has:i,get:l}=Reflect.getPrototypeOf(r),s=i.call(r,e);s||(e=tm(e),s=i.call(r,e));let o=l.call(r,e);return r.set(e,n),s?K(n,o)&&eB(r,"set",e,n):eB(r,"add",e,n),this},delete(e){let t=tm(this),{has:n,get:r}=Reflect.getPrototypeOf(t),i=n.call(t,e);i||(e=tm(e),i=n.call(t,e)),r&&r.call(t,e);let l=t.delete(e);return i&&eB(t,"delete",e,void 0),l},clear(){let e=tm(this),t=0!==e.size,n=e.clear();return t&&eB(e,"clear",void 0,void 0),n}}),["keys","values","entries",Symbol.iterator].forEach(r=>{n[r]=function(...n){let i,l=this.__v_raw,s=tm(l),o="[object Map]"===(i=s,F.call(i)),a="entries"===r||r===Symbol.iterator&&o,c=l[r](...n),u=t?e5:e?tb:ty;return e||eV(s,"iterate","keys"===r&&o?e$:eL),T(Object.create(c),{next(){let{value:e,done:t}=c.next();return t?{value:e,done:t}:{value:a?[u(e[0]),u(e[1])]:u(e),done:t}}})}}),n);return(t,n,i)=>"__v_isReactive"===n?!e:"__v_isReadonly"===n?e:"__v_raw"===n?t:Reflect.get(A(r,n)&&n in t?r:t,n,i)}let te={get:e7(!1,!1)},tt={get:e7(!1,!0)},tn={get:e7(!0,!1)},tr={get:e7(!0,!0)},ti=new WeakMap,tl=new WeakMap,ts=new WeakMap,to=new WeakMap;function ta(e){return tp(e)?e:td(e,!1,e6,te,ti)}function tc(e){return td(e,!1,e4,tt,tl)}function tu(e){return td(e,!0,e3,tn,ts)}function td(e,t,n,r,i){let l;if(!M(e)||e.__v_raw&&!(t&&e.__v_isReactive)||e.__v_skip||!Object.isExtensible(e))return e;let s=i.get(e);if(s)return s;let o=function(e){switch(e){case"Object":case"Array":return 1;case"Map":case"Set":case"WeakMap":case"WeakSet":return 2;default:return 0}}((l=e,F.call(l)).slice(8,-1));if(0===o)return e;let a=new Proxy(e,2===o?r:n);return i.set(e,a),a}function th(e){return tp(e)?th(e.__v_raw):!!(e&&e.__v_isReactive)}function tp(e){return!!(e&&e.__v_isReadonly)}function tf(e){return!!(e&&e.__v_isShallow)}function tg(e){return!!e&&!!e.__v_raw}function tm(e){let t=e&&e.__v_raw;return t?tm(t):e}function tv(e){return!A(e,"__v_skip")&&Object.isExtensible(e)&&J(e,"__v_skip",!0),e}let ty=e=>M(e)?ta(e):e,tb=e=>M(e)?tu(e):e;function t_(e){return!!e&&!0===e.__v_isRef}function tS(e){return tC(e,!1)}function tx(e){return tC(e,!0)}function tC(e,t){return t_(e)?e:new tk(e,t)}class tk{constructor(e,t){this.dep=new eP,this.__v_isRef=!0,this.__v_isShallow=!1,this._rawValue=t?e:tm(e),this._value=t?e:ty(e),this.__v_isShallow=t}get value(){return this.dep.track(),this._value}set value(e){let t=this._rawValue,n=this.__v_isShallow||tf(e)||tp(e);K(e=n?e:tm(e),t)&&(this._rawValue=e,this._value=n?e:ty(e),this.dep.trigger())}}function tT(e){return t_(e)?e.value:e}let tw={get:(e,t,n)=>"__v_raw"===t?e:tT(Reflect.get(e,t,n)),set:(e,t,n,r)=>{let i=e[t];return t_(i)&&!t_(n)?(i.value=n,!0):Reflect.set(e,t,n,r)}};function tN(e){return th(e)?e:new Proxy(e,tw)}class tA{constructor(e){this.__v_isRef=!0,this._value=void 0;const t=this.dep=new eP,{get:n,set:r}=e(t.track.bind(t),t.trigger.bind(t));this._get=n,this._set=r}get value(){return this._value=this._get()}set value(e){this._set(e)}}function tE(e){return new tA(e)}class tI{constructor(e,t,n){this._object=e,this._defaultValue=n,this.__v_isRef=!0,this._value=void 0,this._key=O(t)?t:String(t),this._raw=tm(e);let r=!0,i=e;if(!E(e)||O(this._key)||!L(this._key))do r=!tg(i)||tf(i);while(r&&(i=i.__v_raw));this._shallow=r}get value(){let e=this._object[this._key];return this._shallow&&(e=tT(e)),this._value=void 0===e?this._defaultValue:e}set value(e){if(this._shallow&&t_(this._raw[this._key])){let t=this._object[this._key];if(t_(t)){t.value=e;return}}this._object[this._key]=e}get dep(){var e,t;let n;return e=this._raw,t=this._key,(n=eF.get(e))&&n.get(t)}}class tR{constructor(e){this._getter=e,this.__v_isRef=!0,this.__v_isReadonly=!0,this._value=void 0}get value(){return this._value=this._getter()}}class tO{constructor(e,t,n){this.fn=e,this.setter=t,this._value=void 0,this.dep=new eP(this),this.__v_isRef=!0,this.deps=void 0,this.depsTail=void 0,this.flags=16,this.globalVersion=eO-1,this.next=void 0,this.effect=this,this.__v_isReadonly=!t,this.isSSR=n}notify(){if(this.flags|=16,!(8&this.flags)&&s!==this)return e_(this,!0),!0}get value(){let e=this.dep.track();return eT(this),e&&(e.version=this.dep.version),this._value}set value(e){this.setter&&this.setter(e)}}let tM={},tP=new WeakMap;function tF(e,t=!1,n=g){if(n){let t=tP.get(n);t||tP.set(n,t=[]),t.push(e)}}function tL(e,t=1/0,n){if(t<=0||!M(e)||e.__v_skip||((n=n||new Map).get(e)||0)>=t)return e;if(n.set(e,t),t--,t_(e))tL(e.value,t,n);else if(E(e))for(let r=0;r<e.length;r++)tL(e[r],t,n);else{let r,i;if("[object Set]"===(r=e,F.call(r))||"[object Map]"===(i=e,F.call(i)))e.forEach(e=>{tL(e,t,n)});else{let r;if("[object Object]"===(r=e,F.call(r))){for(let r in e)tL(e[r],t,n);for(let r of Object.getOwnPropertySymbols(e))Object.prototype.propertyIsEnumerable.call(e,r)&&tL(e[r],t,n)}}}return e}function t$(e,t,n,r){try{return r?e(...r):e()}catch(e){tV(e,t,n)}}function tD(e,t,n,r){if(I(e)){let i=t$(e,t,n,r);return i&&P(i)&&i.catch(e=>{tV(e,t,n)}),i}if(E(e)){let i=[];for(let l=0;l<e.length;l++)i.push(tD(e[l],t,n,r));return i}}function tV(e,t,n,r=!0){let i=t?t.vnode:null,{errorHandler:l,throwUnhandledErrorInProduction:s}=t&&t.appContext.config||b;if(t){let r=t.parent,i=t.proxy,s=`https://vuejs.org/error-reference/#runtime-${n}`;for(;r;){let t=r.ec;if(t){for(let n=0;n<t.length;n++)if(!1===t[n](e,i,s))return}r=r.parent}if(l){eE(),t$(l,null,10,[e,i,s]),eI();return}}!function(e,t=!0,n=!1){if(n)throw e;console.error(e)}(e,r,s)}let tB=[],tj=-1,tU=[],tH=null,tq=0,tW=Promise.resolve(),tK=null;function tz(e){let t=tK||tW;return e?t.then(this?e.bind(this):e):t}function tJ(e){if(!(1&e.flags)){let t=tY(e),n=tB[tB.length-1];!n||!(2&e.flags)&&t>=tY(n)?tB.push(e):tB.splice(function(e){let t=tj+1,n=tB.length;for(;t<n;){let r=t+n>>>1,i=tB[r],l=tY(i);l<e||l===e&&2&i.flags?t=r+1:n=r}return t}(t),0,e),e.flags|=1,tG()}}function tG(){tK||(tK=tW.then(function e(t){try{for(tj=0;tj<tB.length;tj++){let e=tB[tj];e&&!(8&e.flags)&&(4&e.flags&&(e.flags&=-2),t$(e,e.i,e.i?15:14),4&e.flags||(e.flags&=-2))}}finally{for(;tj<tB.length;tj++){let e=tB[tj];e&&(e.flags&=-2)}tj=-1,tB.length=0,tZ(),tK=null,(tB.length||tU.length)&&e()}}))}function tX(e){E(e)?tU.push(...e):tH&&-1===e.id?tH.splice(tq+1,0,e):1&e.flags||(tU.push(e),e.flags|=1),tG()}function tQ(e,t,n=tj+1){for(;n<tB.length;n++){let t=tB[n];if(t&&2&t.flags){if(e&&t.id!==e.uid)continue;tB.splice(n,1),n--,4&t.flags&&(t.flags&=-2),t(),4&t.flags||(t.flags&=-2)}}}function tZ(e){if(tU.length){let e=[...new Set(tU)].sort((e,t)=>tY(e)-tY(t));if(tU.length=0,tH)return void tH.push(...e);for(tH=e,tq=0;tq<tH.length;tq++){let e=tH[tq];4&e.flags&&(e.flags&=-2),8&e.flags||e(),e.flags&=-2}tH=null,tq=0}}let tY=e=>null==e.id?2&e.flags?-1:1/0:e.id,t0=null,t1=null;function t2(e){let t=t0;return t0=e,t1=e&&e.type.__scopeId||null,t}function t6(e,t=t0,n){if(!t||e._n)return e;let r=(...n)=>{let i;r._d&&is(-1);let l=t2(t);try{i=e(...n)}finally{t2(l),r._d&&is(1)}return i};return r._n=!0,r._c=!0,r._d=!0,r}function t3(e,t,n,r){let i=e.dirs,l=t&&t.dirs;for(let s=0;s<i.length;s++){let o=i[s];l&&(o.oldValue=l[s].value);let a=o.dir[r];a&&(eE(),tD(a,n,8,[e.el,o,e,t]),eI())}}function t4(e,t){if(iN){let n=iN.provides,r=iN.parent&&iN.parent.provides;r===n&&(n=iN.provides=Object.create(r)),n[e]=t}}function t8(e,t,n=!1){let r=iA();if(r||rx){let i=rx?rx._context.provides:r?null==r.parent||r.ce?r.vnode.appContext&&r.vnode.appContext.provides:r.parent.provides:void 0;if(i&&e in i)return i[e];if(arguments.length>1)return n&&I(t)?t.call(r&&r.proxy):t}}let t5=Symbol.for("v-scx");function t9(e,t){return t7(e,null,{flush:"sync"})}function t7(e,t,n=b){let{flush:r}=n,i=T({},n),s=iN;i.call=(e,t,n)=>tD(e,s,t,n);let o=!1;return"post"===r?i.scheduler=e=>{rW(e,s&&s.suspense)}:"sync"!==r&&(o=!0,i.scheduler=(e,t)=>{t?e():tJ(e)}),i.augmentJob=e=>{t&&(e.flags|=4),o&&(e.flags|=2,s&&(e.id=s.uid,e.i=s))},function(e,t,n=b){let r,i,s,o,{immediate:a,deep:c,once:u,scheduler:d,augmentJob:h,call:p}=n,f=e=>c?e:tf(e)||!1===c||0===c?tL(e,1):tL(e),m=!1,y=!1;if(t_(e)?(i=()=>e.value,m=tf(e)):th(e)?(i=()=>f(e),m=!0):E(e)?(y=!0,m=e.some(e=>th(e)||tf(e)),i=()=>e.map(e=>t_(e)?e.value:th(e)?f(e):I(e)?p?p(e,2):e():void 0)):i=I(e)?t?p?()=>p(e,2):e:()=>{if(s){eE();try{s()}finally{eI()}}let t=g;g=r;try{return p?p(e,3,[o]):e(o)}finally{g=t}}:S,t&&c){let e=i,t=!0===c?1/0:c;i=()=>tL(e(),t)}let _=l,x=()=>{r.stop(),_&&_.active&&w(_.effects,r)};if(u&&t){let e=t;t=(...t)=>{let n=e(...t);return x(),n}}let C=y?Array(e.length).fill(tM):tM,k=e=>{if(1&r.flags&&(r.dirty||e))if(t){let n=r.run();if(e||c||m||(y?n.some((e,t)=>K(e,C[t])):K(n,C))){s&&s();let e=g;g=r;try{let e=[n,C===tM?void 0:y&&C[0]===tM?[]:C,o];C=n,p?p(t,3,e):t(...e)}finally{g=e}}}else r.run()};return h&&h(k),(r=new ey(i)).scheduler=d?()=>d(k,!1):k,o=e=>tF(e,!1,r),s=r.onStop=()=>{let e=tP.get(r);if(e){if(p)p(e,4);else for(let t of e)t();tP.delete(r)}},t?a?k(!0):C=r.run():d?d(k.bind(null,!0),!0):r.run(),x.pause=r.pause.bind(r),x.resume=r.resume.bind(r),x.stop=x,x}(e,t,i)}function ne(e,t,n){let r,i=this.proxy,l=R(e)?e.includes(".")?nt(i,e):()=>i[e]:e.bind(i,i);I(t)?r=t:(r=t.handler,n=t);let s=iE(this),o=t7(l,r.bind(i),n);return s(),o}function nt(e,t){let n=t.split(".");return()=>{let t=e;for(let e=0;e<n.length&&t;e++)t=t[n[e]];return t}}let nn=new WeakMap,nr=Symbol("_vte"),ni=e=>e&&(e.disabled||""===e.disabled),nl=e=>"u">typeof SVGElement&&e instanceof SVGElement,ns=e=>"function"==typeof MathMLElement&&e instanceof MathMLElement,no=(e,t)=>{let n=e&&e.to;return R(n)?t?t(n):null:n};function na(e,t,n,{o:{insert:r},m:i},l=2){0===l&&r(e.targetAnchor,t,n);let{el:s,anchor:o,shapeFlag:a,children:c,props:u}=e,d=2===l;if(d&&r(s,t,n),!nn.has(e)&&(!d||ni(u))&&16&a)for(let e=0;e<c.length;e++)i(c[e],t,n,2);d&&r(o,t,n)}function nc(e,t){let n=e.ctx;if(n&&n.ut){let r,i;for(t?(r=e.el,i=e.anchor):(r=e.targetStart,i=e.targetAnchor);r&&r!==i;)1===r.nodeType&&r.setAttribute("data-v-owner",n.uid),r=r.nextSibling;n.ut()}}function nu(e,t,n,r,i=null){let l=t.targetStart=n(""),s=t.targetAnchor=n("");return l[nr]=s,e&&(r(l,e,i),r(s,e,i)),s}let nd=Symbol("_leaveCb"),nh=Symbol("_enterCb");function np(){let e={isMounted:!1,isLeaving:!1,isUnmounting:!1,leavingVNodes:new Map};return n0(()=>{e.isMounted=!0}),n6(()=>{e.isUnmounting=!0}),e}let nf=[Function,Array],ng={mode:String,appear:Boolean,persisted:Boolean,onBeforeEnter:nf,onEnter:nf,onAfterEnter:nf,onEnterCancelled:nf,onBeforeLeave:nf,onLeave:nf,onAfterLeave:nf,onLeaveCancelled:nf,onBeforeAppear:nf,onAppear:nf,onAfterAppear:nf,onAppearCancelled:nf},nm=e=>{let t=e.subTree;return t.component?nm(t.component):t};function nv(e){let t=e[0];if(e.length>1){for(let n of e)if(n.type!==r9){t=n;break}}return t}let ny={name:"BaseTransition",props:ng,setup(e,{slots:t}){let n=iA(),r=np();return()=>{let i=t.default&&nk(t.default(),!0),l=i&&i.length?nv(i):n.subTree?ib():void 0;if(!l)return;let s=tm(e),{mode:o}=s;if(r.isLeaving)return nS(l);let a=nx(l);if(!a)return nS(l);let c=n_(a,s,r,n,e=>c=e);a.type!==r9&&nC(a,c);let u=n.subTree&&nx(n.subTree);if(u&&u.type!==r9&&!iu(u,a)&&nm(n).type!==r9){let e=n_(u,s,r,n);if(nC(u,e),"out-in"===o&&a.type!==r9)return r.isLeaving=!0,e.afterLeave=()=>{r.isLeaving=!1,8&n.job.flags||n.update(),delete e.afterLeave,u=void 0},nS(l);"in-out"===o&&a.type!==r9?e.delayLeave=(e,t,n)=>{nb(r,u)[String(u.key)]=u,e[nd]=()=>{t(),e[nd]=void 0,delete c.delayedLeave,u=void 0},c.delayedLeave=()=>{n(),delete c.delayedLeave,u=void 0}}:u=void 0}else u&&(u=void 0);return l}}};function nb(e,t){let{leavingVNodes:n}=e,r=n.get(t.type);return r||(r=Object.create(null),n.set(t.type,r)),r}function n_(e,t,n,r,i){let{appear:l,mode:s,persisted:o=!1,onBeforeEnter:a,onEnter:c,onAfterEnter:u,onEnterCancelled:d,onBeforeLeave:h,onLeave:p,onAfterLeave:f,onLeaveCancelled:g,onBeforeAppear:m,onAppear:y,onAfterAppear:b,onAppearCancelled:_}=t,S=String(e.key),x=nb(n,e),C=(e,t)=>{e&&tD(e,r,9,t)},k=(e,t)=>{let n=t[1];C(e,t),E(e)?e.every(e=>e.length<=1)&&n():e.length<=1&&n()},T={mode:s,persisted:o,beforeEnter(t){let r=a;if(!n.isMounted)if(!l)return;else r=m||a;t[nd]&&t[nd](!0);let i=x[S];i&&iu(e,i)&&i.el[nd]&&i.el[nd](),C(r,[t])},enter(t){if(x[S]===e)return;let r=c,i=u,s=d;if(!n.isMounted)if(!l)return;else r=y||c,i=b||u,s=_||d;let o=!1;t[nh]=e=>{o||(o=!0,e?C(s,[t]):C(i,[t]),T.delayedLeave&&T.delayedLeave(),t[nh]=void 0)};let a=t[nh].bind(null,!1);r?k(r,[t,a]):a()},leave(t,r){let i=String(e.key);if(t[nh]&&t[nh](!0),n.isUnmounting)return r();C(h,[t]);let l=!1;t[nd]=n=>{l||(l=!0,r(),n?C(g,[t]):C(f,[t]),t[nd]=void 0,x[i]===e&&delete x[i])};let s=t[nd].bind(null,!1);x[i]=e,p?k(p,[t,s]):s()},clone(e){let l=n_(e,t,n,r,i);return i&&i(l),l}};return T}function nS(e){if(nq(e))return(e=iv(e)).children=null,e}function nx(e){if(!nq(e))return e.type.__isTeleport&&e.children?nv(e.children):e;if(e.component)return e.component.subTree;let{shapeFlag:t,children:n}=e;if(n){if(16&t)return n[0];if(32&t&&I(n.default))return n.default()}}function nC(e,t){6&e.shapeFlag&&e.component?(e.transition=t,nC(e.component.subTree,t)):128&e.shapeFlag?(e.ssContent.transition=t.clone(e.ssContent),e.ssFallback.transition=t.clone(e.ssFallback)):e.transition=t}function nk(e,t=!1,n){let r=[],i=0;for(let l=0;l<e.length;l++){let s=e[l],o=null==n?s.key:String(n)+String(null!=s.key?s.key:l);s.type===r8?(128&s.patchFlag&&i++,r=r.concat(nk(s.children,t,o))):(t||s.type!==r9)&&r.push(null!=o?iv(s,{key:o}):s)}if(i>1)for(let e=0;e<r.length;e++)r[e].patchFlag=-2;return r}function nT(e,t){return I(e)?T({name:e.name},t,{setup:e}):e}function nw(e){e.ids=[e.ids[0]+e.ids[2]+++"-",0,0]}function nN(e,t){let n;return!!((n=Object.getOwnPropertyDescriptor(e,t))&&!n.configurable)}let nA=new WeakMap;function nE(e,t,n,r,i=!1){if(E(e))return void e.forEach((e,l)=>nE(e,t&&(E(t)?t[l]:t),n,r,i));if(nU(r)&&!i){512&r.shapeFlag&&r.type.__asyncResolved&&r.component.subTree.component&&nE(e,t,n,r.component.subTree);return}let l=4&r.shapeFlag?iD(r.component):r.el,s=i?null:l,{i:o,r:a}=e,c=t&&t.r,u=o.refs===b?o.refs={}:o.refs,d=o.setupState,h=tm(d),p=d===b?x:e=>!nN(u,e)&&A(h,e),f=(e,t)=>!(t&&nN(u,t));if(null!=c&&c!==a&&(nI(t),R(c)?(u[c]=null,p(c)&&(d[c]=null)):t_(c)&&(f(c,t.k)&&(c.value=null),t.k&&(u[t.k]=null))),I(a)){eE();try{t$(a,o,12,[s,u])}finally{eI()}}else{let t=R(a),r=t_(a);if(t||r){let o=()=>{if(e.f){let n=t?p(a)?d[a]:u[a]:f()||!e.k?a.value:u[e.k];if(i)E(n)&&w(n,l);else if(E(n))n.includes(l)||n.push(l);else if(t)u[a]=[l],p(a)&&(d[a]=u[a]);else{let t=[l];f(a,e.k)&&(a.value=t),e.k&&(u[e.k]=t)}}else t?(u[a]=s,p(a)&&(d[a]=s)):r&&(f(a,e.k)&&(a.value=s),e.k&&(u[e.k]=s))};if(s){let t=()=>{o(),nA.delete(e)};t.id=-1,nA.set(e,t),rW(t,n)}else nI(e),o()}}}function nI(e){let t=nA.get(e);t&&(t.flags|=8,nA.delete(e))}let nR=!1,nO=()=>{nR||(console.error("Hydration completed but contains mismatches."),nR=!0)},nM=e=>{if(1===e.nodeType){if(e.namespaceURI.includes("svg")&&"foreignObject"!==e.tagName)return"svg";if(e.namespaceURI.includes("MathML"))return"mathml"}},nP=e=>8===e.nodeType;function nF(e){let{mt:t,p:n,o:{patchProp:r,createText:i,nextSibling:l,parentNode:s,remove:o,insert:a,createComment:c}}=e,u=(n,r,o,c,b,_=!1)=>{_=_||!!r.dynamicChildren;let S=nP(n)&&"["===n.data,x=()=>f(n,r,o,c,b,S),{type:C,ref:k,shapeFlag:T,patchFlag:w}=r,N=n.nodeType;r.el=n,-2===w&&(_=!1,r.dynamicChildren=null);let A=null;switch(C){case r5:3!==N?""===r.children?(a(r.el=i(""),s(n),n),A=n):A=x():(n.data!==r.children&&(nO(),n.data=r.children),A=l(n));break;case r9:y(n)?(A=l(n),m(r.el=n.content.firstChild,n,o)):A=8!==N||S?x():l(n);break;case r7:if(S&&(N=(n=l(n)).nodeType),1===N||3===N){A=n;let e=!r.children.length;for(let t=0;t<r.staticCount;t++)e&&(r.children+=1===A.nodeType?A.outerHTML:A.data),t===r.staticCount-1&&(r.anchor=A),A=l(A);return S?l(A):A}x();break;case r8:A=S?p(n,r,o,c,b,_):x();break;default:if(1&T)A=1===N&&r.type.toLowerCase()===n.tagName.toLowerCase()||y(n)?d(n,r,o,c,b,_):x();else if(6&T){r.slotScopeIds=b;let e=s(n);if(A=S?g(n):nP(n)&&"teleport start"===n.data?g(n,n.data,"teleport end"):l(n),t(r,e,null,o,c,nM(e),_),nU(r)&&!r.type.__asyncResolved){let t;S?(t=ig(r8)).anchor=A?A.previousSibling:e.lastChild:t=3===n.nodeType?iy(""):ig("div"),t.el=n,r.component.subTree=t}}else 64&T?A=8!==N?x():r.type.hydrate(n,r,o,c,b,_,e,h):128&T&&(A=r.type.hydrate(n,r,o,c,nM(s(n)),b,_,e,u))}return null!=k&&nE(k,null,c,r),A},d=(e,t,n,i,l,s)=>{s=s||!!t.dynamicChildren;let{type:a,dynamicProps:c,props:u,patchFlag:d,shapeFlag:p,dirs:f,transition:g}=t,b="input"===a||"option"===a,_=!!c;if(b||_||-1!==d){let a;f&&t3(t,null,n,"created");let S=!1;if(y(e)){S=rX(null,g)&&n&&n.vnode.props&&n.vnode.props.appear;let r=e.content.firstChild;if(S){let e=r.getAttribute("class");e&&(r.$cls=e),g.beforeEnter(r)}m(r,e,n),t.el=e=r}if(16&p&&!(u&&(u.innerHTML||u.textContent))){let r=h(e.firstChild,t,e,n,i,l,s);for(r&&!nD(e,1)&&nO();r;){let e=r;r=r.nextSibling,o(e)}}else if(8&p){let n=t.children;`
+`===n[0]&&("PRE"===e.tagName||"TEXTAREA"===e.tagName)&&(n=n.slice(1));let{textContent:r}=e;r!==n&&r!==n.replace(/\r\n|\r/g,`
+`)&&(nD(e,0)||nO(),e.textContent=t.children)}if(u){if(b||_||!s||48&d){let t=e.tagName.includes("-");for(let i in u)(b&&(i.endsWith("value")||"indeterminate"===i)||C(i)&&!$(i)||"."===i[0]||t&&!$(i)||c&&c.includes(i))&&r(e,i,null,u[i],void 0,n)}else if(u.onClick)r(e,"onClick",null,u.onClick,void 0,n);else if(4&d&&th(u.style))for(let e in u.style)u.style[e]}(a=u&&u.onVnodeBeforeMount)&&ik(a,n,t),f&&t3(t,null,n,"beforeMount"),((a=u&&u.onVnodeMounted)||f||S)&&r3(()=>{a&&ik(a,n,t),S&&g.enter(e),f&&t3(t,null,n,"mounted")},i)}return e.nextSibling},h=(e,t,r,s,o,c,d)=>{d=d||!!t.dynamicChildren;let h=t.children,p=h.length,f=!1;for(let t=0;t<p;t++){let g=d?h[t]:h[t]=i_(h[t]),m=g.type===r5;e?(m&&!d&&t+1<p&&i_(h[t+1]).type===r5&&(a(i(e.data.slice(g.children.length)),r,l(e)),e.data=g.children),e=u(e,g,s,o,c,d)):m&&!g.children?a(g.el=i(""),r):(!f&&(f=!0,nD(r,1)||nO()),n(null,g,r,null,s,o,nM(r),c))}return e},p=(e,t,n,r,i,o)=>{let{slotScopeIds:u}=t;u&&(i=i?i.concat(u):u);let d=s(e),p=h(l(e),t,d,n,r,i,o);return p&&nP(p)&&"]"===p.data?l(t.anchor=p):(nO(),a(t.anchor=c("]"),d,p),p)},f=(e,t,r,i,a,c)=>{var u,d,h;if(u=e,d=t,nD(u.parentElement,1)||1===(h=u).nodeType&&nV(h.getAttribute(nL),1)||function({props:e}){let t=e&&e[nL];return"string"==typeof t&&nV(t,1)}(d)||nO(),t.el=null,c){let t=g(e);for(;;){let n=l(e);if(n&&n!==t)o(n);else break}}let p=l(e),f=s(e);return o(e),n(null,t,f,p,r,i,nM(f),a),r&&(r.vnode.el=t.el,rO(r,t.el)),p},g=(e,t="[",n="]")=>{let r=0;for(;e;)if((e=l(e))&&nP(e)&&(e.data===t&&r++,e.data===n))if(0===r)return l(e);else r--;return e},m=(e,t,n)=>{let r=t.parentNode;r&&r.replaceChild(e,t);let i=n;for(;i;)i.vnode.el===t&&(i.vnode.el=i.subTree.el=e),i=i.parent},y=e=>1===e.nodeType&&"TEMPLATE"===e.tagName;return[(e,t)=>{if(!t.hasChildNodes()){n(null,e,t),tZ(),t._vnode=e;return}u(t.firstChild,e,null,null,null),tZ(),t._vnode=e},u]}let nL="data-allow-mismatch",n$={0:"text",1:"children",2:"class",3:"style",4:"attribute"};function nD(e,t){if(0===t||1===t)for(;e&&!e.hasAttribute(nL);)e=e.parentElement;return nV(e&&e.getAttribute(nL),t)}function nV(e,t){if(null==e)return!1;{if(""===e)return!0;let n=e.split(",");return!!(0===t&&n.includes("children"))||n.includes(n$[t])}}let nB=Q().requestIdleCallback||(e=>setTimeout(e,1)),nj=Q().cancelIdleCallback||(e=>clearTimeout(e)),nU=e=>!!e.type.__asyncLoader;function nH(e,t){let{ref:n,props:r,children:i,ce:l}=t.vnode,s=ig(e,r,i);return s.ref=n,s.ce=l,delete t.vnode.ce,s}let nq=e=>e.type.__isKeepAlive;function nW(e,t){let n;if(E(e))return e.some(e=>nW(e,t));if(R(e))return e.split(",").includes(t);return"[object RegExp]"===(n=e,F.call(n))&&(e.lastIndex=0,e.test(t))}function nK(e,t){nJ(e,"a",t)}function nz(e,t){nJ(e,"da",t)}function nJ(e,t,n=iN){let r=e.__wdc||(e.__wdc=()=>{let t=n;for(;t;){if(t.isDeactivated)return;t=t.parent}return e()});if(nQ(t,r,n),n){let e=n.parent;for(;e&&e.parent;)nq(e.parent.vnode)&&function(e,t,n,r){let i=nQ(t,e,r,!0);n3(()=>{w(r[t],i)},n)}(r,t,n,e),e=e.parent}}function nG(e){e.shapeFlag&=-257,e.shapeFlag&=-513}function nX(e){return 128&e.shapeFlag?e.ssContent:e}function nQ(e,t,n=iN,r=!1){if(n){let i=n[e]||(n[e]=[]),l=t.__weh||(t.__weh=(...r)=>{eE();let i=iE(n),l=tD(t,n,e,r);return i(),eI(),l});return r?i.unshift(l):i.push(l),l}}let nZ=e=>(t,n=iN)=>{iO&&"sp"!==e||nQ(e,(...e)=>t(...e),n)},nY=nZ("bm"),n0=nZ("m"),n1=nZ("bu"),n2=nZ("u"),n6=nZ("bum"),n3=nZ("um"),n4=nZ("sp"),n8=nZ("rtg"),n5=nZ("rtc");function n9(e,t=iN){nQ("ec",e,t)}let n7="components",re=Symbol.for("v-ndc");function rt(e,t,n=!0,r=!1){let i=t0||iN;if(i){let n=i.type;if(e===n7){let e=iV(n,!1);if(e&&(e===t||e===j(t)||e===q(j(t))))return n}let l=rn(i[e]||n[e],t)||rn(i.appContext[e],t);return!l&&r?n:l}}function rn(e,t){return e&&(e[t]||e[j(t)]||e[q(j(t))])}let rr=e=>e?iR(e)?iD(e):rr(e.parent):null,ri=T(Object.create(null),{$:e=>e,$el:e=>e.vnode.el,$data:e=>e.data,$props:e=>e.props,$attrs:e=>e.attrs,$slots:e=>e.slots,$refs:e=>e.refs,$parent:e=>rr(e.parent),$root:e=>rr(e.root),$host:e=>e.ce,$emit:e=>e.emit,$options:e=>rh(e),$forceUpdate:e=>e.f||(e.f=()=>{tJ(e.update)}),$nextTick:e=>e.n||(e.n=tz.bind(e.proxy)),$watch:e=>ne.bind(e)}),rl=(e,t)=>e!==b&&!e.__isScriptSetup&&A(e,t),rs={get({_:e},t){let n,r;if("__v_skip"===t)return!0;let{ctx:i,setupState:l,data:s,props:o,accessCache:a,type:c,appContext:u}=e;if("$"!==t[0]){let e=a[t];if(void 0!==e)switch(e){case 1:return l[t];case 2:return s[t];case 4:return i[t];case 3:return o[t]}else{if(rl(l,t))return a[t]=1,l[t];if(s!==b&&A(s,t))return a[t]=2,s[t];if(A(o,t))return a[t]=3,o[t];if(i!==b&&A(i,t))return a[t]=4,i[t];ru&&(a[t]=0)}}let d=ri[t];return d?("$attrs"===t&&eV(e.attrs,"get",""),d(e)):(n=c.__cssModules)&&(n=n[t])?n:i!==b&&A(i,t)?(a[t]=4,i[t]):A(r=u.config.globalProperties,t)?r[t]:void 0},set({_:e},t,n){let{data:r,setupState:i,ctx:l}=e;return rl(i,t)?(i[t]=n,!0):r!==b&&A(r,t)?(r[t]=n,!0):!A(e.props,t)&&!("$"===t[0]&&t.slice(1)in e)&&(l[t]=n,!0)},has({_:{data:e,setupState:t,accessCache:n,ctx:r,appContext:i,props:l,type:s}},o){let a;return!!(n[o]||e!==b&&"$"!==o[0]&&A(e,o)||rl(t,o)||A(l,o)||A(r,o)||A(ri,o)||A(i.config.globalProperties,o)||(a=s.__cssModules)&&a[o])},defineProperty(e,t,n){return null!=n.get?e._.accessCache[t]=0:A(n,"value")&&this.set(e,t,n.value,null),Reflect.defineProperty(e,t,n)}},ro=T({},rs,{get(e,t){if(t!==Symbol.unscopables)return rs.get(e,t,e)},has:(e,t)=>"_"!==t[0]&&!Z(t)});function ra(e){let t=iA();return t.setupContext||(t.setupContext=i$(t))}function rc(e){return E(e)?e.reduce((e,t)=>(e[t]=null,e),{}):e}let ru=!0;function rd(e,t,n){tD(E(e)?e.map(e=>e.bind(t.proxy)):e.bind(t.proxy),t,n)}function rh(e){let t,n=e.type,{mixins:r,extends:i}=n,{mixins:l,optionsCache:s,config:{optionMergeStrategies:o}}=e.appContext,a=s.get(n);return a?t=a:l.length||r||i?(t={},l.length&&l.forEach(e=>rp(t,e,o,!0)),rp(t,n,o)):t=n,M(n)&&s.set(n,t),t}function rp(e,t,n,r=!1){let{mixins:i,extends:l}=t;for(let s in l&&rp(e,l,n,!0),i&&i.forEach(t=>rp(e,t,n,!0)),t)if(r&&"expose"===s);else{let r=rf[s]||n&&n[s];e[s]=r?r(e[s],t[s]):t[s]}return e}let rf={data:rg,props:rb,emits:rb,methods:ry,computed:ry,beforeCreate:rv,created:rv,beforeMount:rv,mounted:rv,beforeUpdate:rv,updated:rv,beforeDestroy:rv,beforeUnmount:rv,destroyed:rv,unmounted:rv,activated:rv,deactivated:rv,errorCaptured:rv,serverPrefetch:rv,components:ry,directives:ry,watch:function(e,t){if(!e)return t;if(!t)return e;let n=T(Object.create(null),e);for(let r in t)n[r]=rv(e[r],t[r]);return n},provide:rg,inject:function(e,t){return ry(rm(e),rm(t))}};function rg(e,t){return t?e?function(){return T(I(e)?e.call(this,this):e,I(t)?t.call(this,this):t)}:t:e}function rm(e){if(E(e)){let t={};for(let n=0;n<e.length;n++)t[e[n]]=e[n];return t}return e}function rv(e,t){return e?[...new Set([].concat(e,t))]:t}function ry(e,t){return e?T(Object.create(null),e,t):t}function rb(e,t){return e?E(e)&&E(t)?[...new Set([...e,...t])]:T(Object.create(null),rc(e),rc(null!=t?t:{})):t}function r_(){return{app:null,config:{isNativeTag:x,performance:!1,globalProperties:{},optionMergeStrategies:{},errorHandler:void 0,warnHandler:void 0,compilerOptions:{}},mixins:[],components:{},directives:{},provides:Object.create(null),optionsCache:new WeakMap,propsCache:new WeakMap,emitsCache:new WeakMap}}let rS=0,rx=null,rC=(e,t)=>"modelValue"===t||"model-value"===t?e.modelModifiers:e[`${t}Modifiers`]||e[`${j(t)}Modifiers`]||e[`${H(t)}Modifiers`];function rk(e,t,...n){let r;if(e.isUnmounted)return;let i=e.vnode.props||b,l=n,s=t.startsWith("update:"),o=s&&rC(i,t.slice(7));o&&(o.trim&&(l=n.map(e=>R(e)?e.trim():e)),o.number&&(l=n.map(G)));let a=i[r=W(t)]||i[r=W(j(t))];!a&&s&&(a=i[r=W(H(t))]),a&&tD(a,e,6,l);let c=i[r+"Once"];if(c){if(e.emitted){if(e.emitted[r])return}else e.emitted={};e.emitted[r]=!0,tD(c,e,6,l)}}let rT=new WeakMap;function rw(e,t){return!!e&&!!C(t)&&(A(e,(t="Once"===(t=t.slice(2))?t:t.replace(/Once$/,""))[0].toLowerCase()+t.slice(1))||A(e,H(t))||A(e,t))}function rN(e){let t,n,{type:r,vnode:i,proxy:l,withProxy:s,propsOptions:[o],slots:a,attrs:c,emit:u,render:d,renderCache:h,props:p,data:f,setupState:g,ctx:m,inheritAttrs:y}=e,b=t2(e);try{if(4&i.shapeFlag){let e=s||l;t=i_(d.call(e,e,h,p,g,f,m)),n=c}else t=i_(r.length>1?r(p,{attrs:c,slots:a,emit:u}):r(p,null)),n=r.props?c:rA(c)}catch(n){ie.length=0,tV(n,e,1),t=ig(r9)}let _=t;if(n&&!1!==y){let e=Object.keys(n),{shapeFlag:t}=_;e.length&&7&t&&(o&&e.some(k)&&(n=rE(n,o)),_=iv(_,n,!1,!0))}return i.dirs&&((_=iv(_,null,!1,!0)).dirs=_.dirs?_.dirs.concat(i.dirs):i.dirs),i.transition&&nC(_,i.transition),t=_,t2(b),t}let rA=e=>{let t;for(let n in e)("class"===n||"style"===n||C(n))&&((t||(t={}))[n]=e[n]);return t},rE=(e,t)=>{let n={};for(let r in e)k(r)&&r.slice(9)in t||(n[r]=e[r]);return n};function rI(e,t,n){let r=Object.keys(t);if(r.length!==Object.keys(e).length)return!0;for(let i=0;i<r.length;i++){let l=r[i];if(rR(t,e,l)&&!rw(n,l))return!0}return!1}function rR(e,t,n){let r=e[n],i=t[n];return"style"===n&&M(r)&&M(i)?!eu(r,i):r!==i}function rO({vnode:e,parent:t,suspense:n},r){for(;t;){let n=t.subTree;if(n.suspense&&n.suspense.activeBranch===e&&(n.suspense.vnode.el=n.el=r,e=n),n===e)(e=t.vnode).el=r,t=t.parent;else break}n&&n.activeBranch===e&&(n.vnode.el=r)}let rM={},rP=e=>Object.getPrototypeOf(e)===rM;function rF(e,t,n,r){let i,[l,s]=e.propsOptions,o=!1;if(t)for(let a in t){let c;if($(a))continue;let u=t[a];l&&A(l,c=j(a))?s&&s.includes(c)?(i||(i={}))[c]=u:n[c]=u:rw(e.emitsOptions,a)||a in r&&u===r[a]||(r[a]=u,o=!0)}if(s){let t=tm(n),r=i||b;for(let i=0;i<s.length;i++){let o=s[i];n[o]=rL(l,t,o,r[o],e,!A(r,o))}}return o}function rL(e,t,n,r,i,l){let s=e[n];if(null!=s){let e=A(s,"default");if(e&&void 0===r){let e=s.default;if(s.type!==Function&&!s.skipFactory&&I(e)){let{propsDefaults:l}=i;if(n in l)r=l[n];else{let s=iE(i);r=l[n]=e.call(null,t),s()}}else r=e;i.ce&&i.ce._setProp(n,r)}s[0]&&(l&&!e?r=!1:s[1]&&(""===r||r===H(n))&&(r=!0))}return r}let r$=new WeakMap;function rD(e){return!("$"===e[0]||$(e))}let rV=e=>"_"===e||"_ctx"===e||"$stable"===e,rB=e=>E(e)?e.map(i_):[i_(e)],rj=(e,t,n)=>{if(t._n)return t;let r=t6((...e)=>rB(t(...e)),n);return r._c=!1,r},rU=(e,t,n)=>{let r=e._ctx;for(let n in e){if(rV(n))continue;let i=e[n];if(I(i))t[n]=rj(n,i,r);else if(null!=i){let e=rB(i);t[n]=()=>e}}},rH=(e,t)=>{let n=rB(t);e.slots.default=()=>n},rq=(e,t,n)=>{for(let r in t)(n||!rV(r))&&(e[r]=t[r])},rW=r3;function rK(e){return rz(e,nF)}function rz(e,t){var n;let r,i;Q().__VUE__=!0;let{insert:l,remove:s,patchProp:o,createElement:a,createText:c,createComment:d,setText:h,setElementText:p,parentNode:f,nextSibling:g,setScopeId:m=S,insertStaticContent:y}=e,x=(e,t,n,r=null,i=null,l=null,s,o=null,a=!!t.dynamicChildren)=>{if(e===t)return;e&&!iu(e,t)&&(r=es(e),et(e,i,l,!0),e=null),-2===t.patchFlag&&(a=!1,t.dynamicChildren=null);let{type:c,ref:u,shapeFlag:d}=t;switch(c){case r5:C(e,t,n,r);break;case r9:k(e,t,n,r);break;case r7:null==e&&w(t,n,r,s);break;case r8:B(e,t,n,r,i,l,s,o,a);break;default:1&d?N(e,t,n,r,i,l,s,o,a):6&d?U(e,t,n,r,i,l,s,o,a):64&d?c.process(e,t,n,r,i,l,s,o,a,ec):128&d&&c.process(e,t,n,r,i,l,s,o,a,ec)}null!=u&&i?nE(u,e&&e.ref,l,t||e,!t):null==u&&e&&null!=e.ref&&nE(e.ref,null,l,e,!0)},C=(e,t,n,r)=>{if(null==e)l(t.el=c(t.children),n,r);else{let n=t.el=e.el;t.children!==e.children&&h(n,t.children)}},k=(e,t,n,r)=>{null==e?l(t.el=d(t.children||""),n,r):t.el=e.el},w=(e,t,n,r)=>{[e.el,e.anchor]=y(e.children,t,n,r,e.el,e.anchor)},N=(e,t,n,r,i,l,s,o,a)=>{if("svg"===t.type?s="svg":"math"===t.type&&(s="mathml"),null==e)R(t,n,r,i,l,s,o,a);else{let n=e.el&&e.el._isVueCE?e.el:null;try{n&&n._beginPatch(),L(e,t,i,l,s,o,a)}finally{n&&n._endPatch()}}},R=(e,t,n,r,i,s,c,u)=>{let d,h,{props:f,shapeFlag:g,transition:m,dirs:y}=e;if(d=e.el=a(e.type,s,f&&f.is,f),8&g?p(d,e.children):16&g&&F(e.children,d,null,r,i,rJ(e,s),c,u),y&&t3(e,null,r,"created"),O(d,e,e.scopeId,c,r),f){for(let e in f)"value"===e||$(e)||o(d,e,null,f[e],s,r);"value"in f&&o(d,"value",null,f.value,s),(h=f.onVnodeBeforeMount)&&ik(h,r,e)}y&&t3(e,null,r,"beforeMount");let b=rX(i,m);b&&m.beforeEnter(d),l(d,t,n),((h=f&&f.onVnodeMounted)||b||y)&&rW(()=>{h&&ik(h,r,e),b&&m.enter(d),y&&t3(e,null,r,"mounted")},i)},O=(e,t,n,r,i)=>{if(n&&m(e,n),r)for(let t=0;t<r.length;t++)m(e,r[t]);if(i){let n=i.subTree;if(t===n||rY(n.type)&&(n.ssContent===t||n.ssFallback===t)){let t=i.vnode;O(e,t,t.scopeId,t.slotScopeIds,i.parent)}}},F=(e,t,n,r,i,l,s,o,a=0)=>{for(let c=a;c<e.length;c++)x(null,e[c]=o?iS(e[c]):i_(e[c]),t,n,r,i,l,s,o)},L=(e,t,n,r,i,l,s)=>{let a,c=t.el=e.el,{patchFlag:u,dynamicChildren:d,dirs:h}=t;u|=16&e.patchFlag;let f=e.props||b,g=t.props||b;if(n&&rG(n,!1),(a=g.onVnodeBeforeUpdate)&&ik(a,n,t,e),h&&t3(t,e,n,"beforeUpdate"),n&&rG(n,!0),d&&(!e.dynamicChildren||e.dynamicChildren.length!==d.length)&&(u=0,s=!1,d=null),(f.innerHTML&&null==g.innerHTML||f.textContent&&null==g.textContent)&&p(c,""),d?D(e.dynamicChildren,d,c,n,r,rJ(t,i),l):s||X(e,t,c,null,n,r,rJ(t,i),l,!1),u>0){if(16&u)V(c,f,g,n,i);else if(2&u&&f.class!==g.class&&o(c,"class",null,g.class,i),4&u&&o(c,"style",f.style,g.style,i),8&u){let e=t.dynamicProps;for(let t=0;t<e.length;t++){let r=e[t],l=f[r],s=g[r];(s!==l||"value"===r)&&o(c,r,l,s,i,n)}}1&u&&e.children!==t.children&&p(c,t.children)}else s||null!=d||V(c,f,g,n,i);((a=g.onVnodeUpdated)||h)&&rW(()=>{a&&ik(a,n,t,e),h&&t3(t,e,n,"updated")},r)},D=(e,t,n,r,i,l,s)=>{for(let o=0;o<t.length;o++){let a=e[o],c=t[o],u=a.el&&(a.type===r8||!iu(a,c)||198&a.shapeFlag)?f(a.el):n;x(a,c,u,null,r,i,l,s,!0)}},V=(e,t,n,r,i)=>{if(t!==n){if(t!==b)for(let l in t)$(l)||l in n||o(e,l,t[l],null,i,r);for(let l in n){if($(l))continue;let s=n[l],a=t[l];s!==a&&"value"!==l&&o(e,l,a,s,i,r)}"value"in n&&o(e,"value",t.value,n.value,i)}},B=(e,t,n,r,i,s,o,a,u)=>{let d=t.el=e?e.el:c(""),h=t.anchor=e?e.anchor:c(""),{patchFlag:p,dynamicChildren:f,slotScopeIds:g}=t;g&&(a=a?a.concat(g):g),null==e?(l(d,n,r),l(h,n,r),F(t.children||[],n,h,i,s,o,a,u)):p>0&&64&p&&f&&e.dynamicChildren&&e.dynamicChildren.length===f.length?(D(e.dynamicChildren,f,n,i,s,o,a),(null!=t.key||i&&t===i.subTree)&&rQ(e,t,!0)):X(e,t,n,h,i,s,o,a,u)},U=(e,t,n,r,i,l,s,o,a)=>{t.slotScopeIds=o,null==e?512&t.shapeFlag?i.ctx.activate(t,n,r,s,a):q(t,n,r,i,l,s,a):W(e,t,a)},q=(e,t,n,r,i,l,s)=>{var o,a,c;let d,h,p,f=(o=e,a=r,c=i,d=o.type,h=(a?a.appContext:o.appContext)||iT,(p={uid:iw++,vnode:o,type:d,parent:a,appContext:h,root:null,next:null,subTree:null,effect:null,update:null,job:null,scope:new em(!0),render:null,proxy:null,exposed:null,exposeProxy:null,withProxy:null,provides:a?a.provides:Object.create(h.provides),ids:a?a.ids:["",0,0],accessCache:null,renderCache:[],components:null,directives:null,propsOptions:function e(t,n,r=!1){let i=r?r$:n.propsCache,l=i.get(t);if(l)return l;let s=t.props,o={},a=[],c=!1;if(!I(t)){let i=t=>{c=!0;let[r,i]=e(t,n,!0);T(o,r),i&&a.push(...i)};!r&&n.mixins.length&&n.mixins.forEach(i),t.extends&&i(t.extends),t.mixins&&t.mixins.forEach(i)}if(!s&&!c)return M(t)&&i.set(t,_),_;if(E(s))for(let e=0;e<s.length;e++){let t=j(s[e]);rD(t)&&(o[t]=b)}else if(s)for(let e in s){let t=j(e);if(rD(t)){let n=s[e],r=o[t]=E(n)||I(n)?{type:n}:T({},n),i=r.type,l=!1,c=!0;if(E(i))for(let e=0;e<i.length;++e){let t=i[e],n=I(t)&&t.name;if("Boolean"===n){l=!0;break}"String"===n&&(c=!1)}else l=I(i)&&"Boolean"===i.name;r[0]=l,r[1]=c,(l||A(r,"default"))&&a.push(t)}}let u=[o,a];return M(t)&&i.set(t,u),u}(d,h),emitsOptions:function e(t,n,r=!1){let i=r?rT:n.emitsCache,l=i.get(t);if(void 0!==l)return l;let s=t.emits,o={},a=!1;if(!I(t)){let i=t=>{let r=e(t,n,!0);r&&(a=!0,T(o,r))};!r&&n.mixins.length&&n.mixins.forEach(i),t.extends&&i(t.extends),t.mixins&&t.mixins.forEach(i)}return s||a?(E(s)?s.forEach(e=>o[e]=null):T(o,s),M(t)&&i.set(t,o),o):(M(t)&&i.set(t,null),null)}(d,h),emit:null,emitted:null,propsDefaults:b,inheritAttrs:d.inheritAttrs,ctx:b,data:b,props:b,attrs:b,slots:b,refs:b,setupState:b,setupContext:null,suspense:c,suspenseId:c?c.pendingId:0,asyncDep:null,asyncResolved:!1,isMounted:!1,isUnmounted:!1,isDeactivated:!1,bc:null,c:null,bm:null,m:null,bu:null,u:null,um:null,bum:null,da:null,a:null,rtg:null,rtc:null,ec:null,sp:null}).ctx={_:p},p.root=a?a.root:p,p.emit=rk.bind(null,p),o.ce&&o.ce(p),e.component=p);if(nq(e)&&(f.ctx.renderer=ec),function(e,t=!1,n=!1){t&&u(t);let{props:r,children:i}=e.vnode,l=iR(e);!function(e,t,n,r=!1){let i={},l=Object.create(rM);for(let n in e.propsDefaults=Object.create(null),rF(e,t,i,l),e.propsOptions[0])n in i||(i[n]=void 0);n?e.props=r?i:tc(i):e.type.props?e.props=i:e.props=l,e.attrs=l}(e,r,l,t);var s=n||t;let o=e.slots=Object.create(rM);if(32&e.vnode.shapeFlag){let e=i._;e?(rq(o,i,s),s&&J(o,"_",e,!0)):rU(i,o)}else i&&rH(e,i);l&&function(e,t){let n=e.type;e.accessCache=Object.create(null),e.proxy=new Proxy(e.ctx,rs);let{setup:r}=n;if(r){eE();let n=e.setupContext=r.length>1?i$(e):null,i=iE(e),l=t$(r,e,0,[e.props,n]),s=P(l);if(eI(),i(),(s||e.sp)&&!nU(e)&&nw(e),s){if(l.then(iI,iI),t)return l.then(n=>{iM(e,n,t)}).catch(t=>{tV(t,e,0)});e.asyncDep=l}else iM(e,l,t)}else iF(e,t)}(e,t),t&&u(!1)}(f,!1,s),f.asyncDep){if(i&&i.registerDep(f,K,s),!e.el){let r=f.subTree=ig(r9);k(null,r,t,n),e.placeholder=r.el}}else K(f,e,t,n,i,l,s)},W=(e,t,n)=>{let r=t.component=e.component;if(function(e,t,n){let{props:r,children:i,component:l}=e,{props:s,children:o,patchFlag:a}=t,c=l.emitsOptions;if(t.dirs||t.transition)return!0;if(!n||!(a>=0))return(!!i||!!o)&&(!o||!o.$stable)||r!==s&&(r?!s||rI(r,s,c):!!s);if(1024&a)return!0;if(16&a)return r?rI(r,s,c):!!s;if(8&a){let e=t.dynamicProps;for(let t=0;t<e.length;t++){let n=e[t];if(rR(s,r,n)&&!rw(c,n))return!0}}return!1}(e,t,n))if(r.asyncDep&&!r.asyncResolved)return void G(r,t,n);else r.next=t,r.update();else t.el=e.el,r.vnode=t},K=(e,t,n,r,l,s,o)=>{e.scope.on();let a=e.effect=new ey(()=>{if(e.isMounted){let t,{next:n,bu:r,u:i,parent:a,vnode:u}=e;{let t=function e(t){let n=t.subTree.component;if(n)if(n.asyncDep&&!n.asyncResolved)return n;else return e(n)}(e);if(t){n&&(n.el=u.el,G(e,n,o)),t.asyncDep.then(()=>{rW(()=>{e.isUnmounted||c()},l)});return}}let d=n;rG(e,!1),n?(n.el=u.el,G(e,n,o)):n=u,r&&z(r),(t=n.props&&n.props.onVnodeBeforeUpdate)&&ik(t,a,n,u),rG(e,!0);let h=rN(e),p=e.subTree;e.subTree=h,x(p,h,f(p.el),es(p),e,l,s),n.el=h.el,null===d&&rO(e,h.el),i&&rW(i,l),(t=n.props&&n.props.onVnodeUpdated)&&rW(()=>ik(t,a,n,u),l)}else{let o,{el:a,props:c}=t,{bm:u,m:d,parent:h,root:p,type:f}=e,g=nU(t);if(rG(e,!1),u&&z(u),!g&&(o=c&&c.onVnodeBeforeMount)&&ik(o,h,t),rG(e,!0),a&&i){let t=()=>{e.subTree=rN(e),i(a,e.subTree,e,l,null)};g&&f.__asyncHydrate?f.__asyncHydrate(a,e,t):t()}else{p.ce&&p.ce._hasShadowRoot()&&p.ce._injectChildStyle(f,e.parent?e.parent.type:void 0);let i=e.subTree=rN(e);x(null,i,n,r,e,l,s),t.el=i.el}if(d&&rW(d,l),!g&&(o=c&&c.onVnodeMounted)){let e=t;rW(()=>ik(o,h,e),l)}(256&t.shapeFlag||h&&nU(h.vnode)&&256&h.vnode.shapeFlag)&&e.a&&rW(e.a,l),e.isMounted=!0,t=n=r=null}});e.scope.off();let c=e.update=a.run.bind(a),u=e.job=a.runIfDirty.bind(a);u.i=e,u.id=e.uid,a.scheduler=()=>tJ(u),rG(e,!0),c()},G=(e,t,n)=>{t.component=e;let r=e.vnode.props;e.vnode=t,e.next=null,function(e,t,n,r){let{props:i,attrs:l,vnode:{patchFlag:s}}=e,o=tm(i),[a]=e.propsOptions,c=!1;if((r||s>0)&&!(16&s)){if(8&s){let n=e.vnode.dynamicProps;for(let r=0;r<n.length;r++){let s=n[r];if(rw(e.emitsOptions,s))continue;let u=t[s];if(a)if(A(l,s))u!==l[s]&&(l[s]=u,c=!0);else{let t=j(s);i[t]=rL(a,o,t,u,e,!1)}else u!==l[s]&&(l[s]=u,c=!0)}}}else{let r;for(let s in rF(e,t,i,l)&&(c=!0),o)t&&(A(t,s)||(r=H(s))!==s&&A(t,r))||(a?n&&(void 0!==n[s]||void 0!==n[r])&&(i[s]=rL(a,o,s,void 0,e,!0)):delete i[s]);if(l!==o)for(let e in l)t&&A(t,e)||(delete l[e],c=!0)}c&&eB(e.attrs,"set","")}(e,t.props,r,n),((e,t,n)=>{let{vnode:r,slots:i}=e,l=!0,s=b;if(32&r.shapeFlag){let e=t._;e?n&&1===e?l=!1:rq(i,t,n):(l=!t.$stable,rU(t,i)),s=t}else t&&(rH(e,t),s={default:1});if(l)for(let e in i)rV(e)||null!=s[e]||delete i[e]})(e,t.children,n),eE(),tQ(e),eI()},X=(e,t,n,r,i,l,s,o,a=!1)=>{let c=e&&e.children,u=e?e.shapeFlag:0,d=t.children,{patchFlag:h,shapeFlag:f}=t;if(h>0){if(128&h)return void Y(c,d,n,r,i,l,s,o,a);else if(256&h)return void Z(c,d,n,r,i,l,s,o,a)}8&f?(16&u&&el(c,i,l),d!==c&&p(n,d)):16&u?16&f?Y(c,d,n,r,i,l,s,o,a):el(c,i,l,!0):(8&u&&p(n,""),16&f&&F(d,n,r,i,l,s,o,a))},Z=(e,t,n,r,i,l,s,o,a)=>{let c;e=e||_,t=t||_;let u=e.length,d=t.length,h=Math.min(u,d);for(c=0;c<h;c++){let r=t[c]=a?iS(t[c]):i_(t[c]);x(e[c],r,n,null,i,l,s,o,a)}u>d?el(e,i,l,!0,!1,h):F(t,n,r,i,l,s,o,a,h)},Y=(e,t,n,r,i,l,s,o,a)=>{let c=0,u=t.length,d=e.length-1,h=u-1;for(;c<=d&&c<=h;){let r=e[c],u=t[c]=a?iS(t[c]):i_(t[c]);if(iu(r,u))x(r,u,n,null,i,l,s,o,a);else break;c++}for(;c<=d&&c<=h;){let r=e[d],c=t[h]=a?iS(t[h]):i_(t[h]);if(iu(r,c))x(r,c,n,null,i,l,s,o,a);else break;d--,h--}if(c>d){if(c<=h){let e=h+1,d=e<u?t[e].el:r;for(;c<=h;)x(null,t[c]=a?iS(t[c]):i_(t[c]),n,d,i,l,s,o,a),c++}}else if(c>h)for(;c<=d;)et(e[c],i,l,!0),c++;else{let p,f=c,g=c,m=new Map;for(c=g;c<=h;c++){let e=t[c]=a?iS(t[c]):i_(t[c]);null!=e.key&&m.set(e.key,c)}let y=0,b=h-g+1,S=!1,C=0,k=Array(b);for(c=0;c<b;c++)k[c]=0;for(c=f;c<=d;c++){let r,u=e[c];if(y>=b){et(u,i,l,!0);continue}if(null!=u.key)r=m.get(u.key);else for(p=g;p<=h;p++)if(0===k[p-g]&&iu(u,t[p])){r=p;break}void 0===r?et(u,i,l,!0):(k[r-g]=c+1,r>=C?C=r:S=!0,x(u,t[r],n,null,i,l,s,o,a),y++)}let T=S?function(e){let t,n,r,i,l,s=e.slice(),o=[0],a=e.length;for(t=0;t<a;t++){let a=e[t];if(0!==a){if(e[n=o[o.length-1]]<a){s[t]=n,o.push(t);continue}for(r=0,i=o.length-1;r<i;)e[o[l=r+i>>1]]<a?r=l+1:i=l;a<e[o[r]]&&(r>0&&(s[t]=o[r-1]),o[r]=t)}}for(r=o.length,i=o[r-1];r-- >0;)o[r]=i,i=s[i];return o}(k):_;for(p=T.length-1,c=b-1;c>=0;c--){let e=g+c,d=t[e],h=t[e+1],f=e+1<u?h.el||function e(t){if(t.placeholder)return t.placeholder;let n=t.component;return n?e(n.subTree):null}(h):r;0===k[c]?x(null,d,n,f,i,l,s,o,a):S&&(p<0||c!==T[p]?ee(d,n,f,2):p--)}}},ee=(e,t,n,r,i=null)=>{let{el:o,type:a,transition:c,children:u,shapeFlag:d}=e;if(6&d)return void ee(e.component.subTree,t,n,r);if(128&d)return void e.suspense.move(t,n,r);if(64&d)return void a.move(e,t,n,ec);if(a===r8){l(o,t,n);for(let e=0;e<u.length;e++)ee(u[e],t,n,r);l(e.anchor,t,n);return}if(a===r7)return void(({el:e,anchor:t},n,r)=>{let i;for(;e&&e!==t;)i=g(e),l(e,n,r),e=i;l(t,n,r)})(e,t,n);if(2!==r&&1&d&&c)if(0===r)c.persisted&&!o[nd]?l(o,t,n):(c.beforeEnter(o),l(o,t,n),rW(()=>c.enter(o),i));else{let{leave:r,delayLeave:i,afterLeave:a}=c,u=()=>{e.ctx.isUnmounted?s(o):l(o,t,n)},d=()=>{let e=o._isLeaving||!!o[nd];o._isLeaving&&o[nd](!0),c.persisted&&!e?u():r(o,()=>{u(),a&&a()})};i?i(o,u,d):d()}else l(o,t,n)},et=(e,t,n,r=!1,i=!1)=>{let l,{type:s,props:o,ref:a,children:c,dynamicChildren:u,shapeFlag:d,patchFlag:h,dirs:p,cacheIndex:f,memo:g}=e;if(-2===h&&(i=!1),null!=a&&(eE(),nE(a,null,n,e,!0),eI()),null!=f&&(t.renderCache[f]=void 0),256&d)return void t.ctx.deactivate(e);let m=1&d&&p,y=!nU(e);if(y&&(l=o&&o.onVnodeBeforeUnmount)&&ik(l,t,e),6&d)ei(e.component,n,r);else{if(128&d)return void e.suspense.unmount(n,r);m&&t3(e,null,t,"beforeUnmount"),64&d?e.type.remove(e,t,n,ec,r):u&&!u.hasOnce&&(s!==r8||h>0&&64&h)?el(u,t,n,!1,!0):(s===r8&&384&h||!i&&16&d)&&el(c,t,n),r&&en(e)}let b=null!=g&&null==f;(y&&(l=o&&o.onVnodeUnmounted)||m||b)&&rW(()=>{l&&ik(l,t,e),m&&t3(e,null,t,"unmounted"),b&&(e.el=null)},n)},en=e=>{let{type:t,el:n,anchor:r,transition:i}=e;if(t===r8)return void er(n,r);if(t===r7)return void(({el:e,anchor:t})=>{let n;for(;e&&e!==t;)n=g(e),s(e),e=n;s(t)})(e);let l=()=>{s(n),i&&!i.persisted&&i.afterLeave&&i.afterLeave()};if(1&e.shapeFlag&&i&&!i.persisted){let{leave:t,delayLeave:r}=i,s=()=>t(n,l);r?r(e.el,l,s):s()}else l()},er=(e,t)=>{let n;for(;e!==t;)n=g(e),s(e),e=n;s(t)},ei=(e,t,n)=>{let{bum:r,scope:i,job:l,subTree:s,um:o,m:a,a:c}=e;rZ(a),rZ(c),r&&z(r),i.stop(),l&&(l.flags|=8,et(s,e,t,n)),o&&rW(o,t),rW(()=>{e.isUnmounted=!0},t)},el=(e,t,n,r=!1,i=!1,l=0)=>{for(let s=l;s<e.length;s++)et(e[s],t,n,r,i)},es=e=>{if(6&e.shapeFlag)return es(e.component.subTree);if(128&e.shapeFlag)return e.suspense.next();let t=g(e.anchor||e.el),n=t&&t[nr];return n?g(n):t},eo=!1,ea=(e,t,n)=>{let r;null==e?t._vnode&&(et(t._vnode,null,null,!0),r=t._vnode.component):x(t._vnode||null,e,t,null,null,null,n),t._vnode=e,eo||(eo=!0,tQ(r),tZ(),eo=!1)},ec={p:x,um:et,m:ee,r:en,mt:q,mc:F,pc:X,pbc:D,n:es,o:e};return t&&([r,i]=t(ec)),{render:ea,hydrate:r,createApp:(n=r,function(e,t=null){I(e)||(e=T({},e)),null==t||M(t)||(t=null);let r=r_(),i=new WeakSet,l=[],s=!1,o=r.app={_uid:rS++,_component:e,_props:t,_container:null,_context:r,_instance:null,version:iH,get config(){return r.config},set config(v){},use:(e,...t)=>(i.has(e)||(e&&I(e.install)?(i.add(e),e.install(o,...t)):I(e)&&(i.add(e),e(o,...t))),o),mixin:e=>(r.mixins.includes(e)||r.mixins.push(e),o),component:(e,t)=>t?(r.components[e]=t,o):r.components[e],directive:(e,t)=>t?(r.directives[e]=t,o):r.directives[e],mount(i,l,a){if(!s){let c=o._ceVNode||ig(e,t);return c.appContext=r,!0===a?a="svg":!1===a&&(a=void 0),l&&n?n(c,i):ea(c,i,a),s=!0,o._container=i,i.__vue_app__=o,iD(c.component)}},onUnmount(e){l.push(e)},unmount(){s&&(tD(l,o._instance,16),ea(null,o._container),delete o._container.__vue_app__)},provide:(e,t)=>(r.provides[e]=t,o),runWithContext(e){let t=rx;rx=o;try{return e()}finally{rx=t}}};return o})}}function rJ({type:e,props:t},n){return"svg"===n&&"foreignObject"===e||"mathml"===n&&"annotation-xml"===e&&t&&t.encoding&&t.encoding.includes("html")?void 0:n}function rG({effect:e,job:t},n){n?(e.flags|=32,t.flags|=4):(e.flags&=-33,t.flags&=-5)}function rX(e,t){return(!e||e&&!e.pendingBranch)&&t&&!t.persisted}function rQ(e,t,n=!1){let r=e.children,i=t.children;if(E(r)&&E(i))for(let e=0;e<r.length;e++){let t=r[e],l=i[e];1&l.shapeFlag&&!l.dynamicChildren&&((l.patchFlag<=0||32===l.patchFlag)&&((l=i[e]=iS(i[e])).el=t.el),n||-2===l.patchFlag||rQ(t,l)),l.type===r5&&(-1===l.patchFlag&&(l=i[e]=iS(l)),l.el=t.el),l.type!==r9||l.el||(l.el=t.el)}}function rZ(e){if(e)for(let t=0;t<e.length;t++)e[t].flags|=8}let rY=e=>e.__isSuspense,r0=0;function r1(e,t){let n=e.props&&e.props[t];I(n)&&n()}function r2(e,t,n,r,i,l,s,o,a,c,u=!1){var d;let h,p,{p:f,m:g,um:m,n:y,o:{parentNode:b,remove:_}}=c,S=null!=(h=(d=e).props&&d.props.suspensible)&&!1!==h;S&&t&&t.pendingBranch&&(p=t.pendingId,t.deps++);let x=e.props?X(e.props.timeout):void 0,C=l,k={vnode:e,parent:t,parentComponent:n,namespace:s,container:r,hiddenContainer:i,deps:0,pendingId:r0++,timeout:"number"==typeof x?x:-1,activeBranch:null,isFallbackMountPending:!1,pendingBranch:null,isInFallback:!u,isHydrating:u,isUnmounted:!1,effects:[],resolve(e=!1,n=!1){let{vnode:r,activeBranch:i,pendingBranch:s,pendingId:o,effects:a,parentComponent:c,container:u,isInFallback:d}=k,h=!1;if(k.isHydrating)k.isHydrating=!1;else if(!e){h=i&&s.transition&&"out-in"===s.transition.mode;let e=!1;h&&(i.transition.afterLeave=()=>{o===k.pendingId&&(g(s,u,l!==C||e?l:y(i),0),tX(a),d&&r.ssFallback&&(r.ssFallback.el=null))}),i&&!k.isFallbackMountPending&&(b(i.el)===u&&(l=y(i),e=!0),m(i,c,k,!0),!h&&d&&r.ssFallback&&rW(()=>r.ssFallback.el=null,k)),h||g(s,u,l,0)}k.isFallbackMountPending=!1,r4(k,s),k.pendingBranch=null,k.isInFallback=!1;let f=k.parent,_=!1;for(;f;){if(f.pendingBranch){f.effects.push(...a),_=!0;break}f=f.parent}_||h||tX(a),k.effects=[],S&&t&&t.pendingBranch&&p===t.pendingId&&(t.deps--,0!==t.deps||n||t.resolve()),r1(r,"onResolve")},fallback(e){if(!k.pendingBranch)return;let{vnode:t,activeBranch:n,parentComponent:r,container:i,namespace:l}=k;r1(t,"onFallback");let s=y(n),c=()=>{k.isFallbackMountPending=!1,k.isInFallback&&(f(null,e,i,s,r,null,l,o,a),r4(k,e))},u=e.transition&&"out-in"===e.transition.mode;u&&(k.isFallbackMountPending=!0,n.transition.afterLeave=c),k.isInFallback=!0,m(n,r,null,!0),u||c()},move(e,t,n){k.activeBranch&&g(k.activeBranch,e,t,n),k.container=e},next:()=>k.activeBranch&&y(k.activeBranch),registerDep(e,t,n){let r=!!k.pendingBranch;r&&k.deps++;let i=e.vnode.el;e.asyncDep.catch(t=>{tV(t,e,0)}).then(l=>{if(e.isUnmounted||k.isUnmounted||k.pendingId!==e.suspenseId)return;iI(),e.asyncResolved=!0;let{vnode:o}=e;iM(e,l,!1),i&&(o.el=i);let a=!i&&e.subTree.el;t(e,o,b(i||e.subTree.el),i?null:y(e.subTree),k,s,n),a&&(o.placeholder=null,_(a)),rO(e,o.el),r&&0==--k.deps&&k.resolve()})},unmount(e,t){k.isUnmounted=!0,k.activeBranch&&m(k.activeBranch,n,e,t),k.pendingBranch&&m(k.pendingBranch,n,e,t)}};return k}function r6(e){let t;if(I(e)){let n=il&&e._c;n&&(e._d=!1,ir()),e=e(),n&&(e._d=!0,t=it,ii())}return E(e)&&(e=function(e){let t;for(let n=0;n<e.length;n++){let r=e[n];if(!ic(r))return;if(r.type!==r9||"v-if"===r.children)if(t)return;else t=r}return t}(e)),e=i_(e),t&&!e.dynamicChildren&&(e.dynamicChildren=t.filter(t=>t!==e)),e}function r3(e,t){t&&t.pendingBranch?E(e)?t.effects.push(...e):t.effects.push(e):tX(e)}function r4(e,t){e.activeBranch=t;let{vnode:n,parentComponent:r}=e,i=t.el;for(;!i&&t.component;)i=(t=t.component.subTree).el;n.el=i,r&&r.subTree===n&&(r.vnode.el=i,rO(r,i))}let r8=Symbol.for("v-fgt"),r5=Symbol.for("v-txt"),r9=Symbol.for("v-cmt"),r7=Symbol.for("v-stc"),ie=[],it=null;function ir(e=!1){ie.push(it=e?null:[])}function ii(){ie.pop(),it=ie[ie.length-1]||null}let il=1;function is(e,t=!1){il+=e,e<0&&it&&t&&(it.hasOnce=!0)}function io(e){return e.dynamicChildren=il>0?it||_:null,ii(),il>0&&it&&it.push(e),e}function ia(e,t,n,r,i){return io(ig(e,t,n,r,i,!0))}function ic(e){return!!e&&!0===e.__v_isVNode}function iu(e,t){return e.type===t.type&&e.key===t.key}let id=({key:e})=>null!=e?e:null,ih=({ref:e,ref_key:t,ref_for:n})=>("number"==typeof e&&(e=""+e),null!=e?R(e)||t_(e)||I(e)?{i:t0,r:e,k:t,f:!!n}:e:null);function ip(e,t=null,n=null,r=0,i=null,l=+(e!==r8),s=!1,o=!1){let a={__v_isVNode:!0,__v_skip:!0,type:e,props:t,key:t&&id(t),ref:t&&ih(t),scopeId:t1,slotScopeIds:null,children:n,component:null,suspense:null,ssContent:null,ssFallback:null,dirs:null,transition:null,el:null,anchor:null,target:null,targetStart:null,targetAnchor:null,staticCount:0,shapeFlag:l,patchFlag:r,dynamicProps:i,dynamicChildren:null,appContext:null,ctx:t0};return o?(ix(a,n),128&l&&e.normalize(a)):n&&(a.shapeFlag|=R(n)?8:16),il>0&&!s&&it&&(a.patchFlag>0||6&l)&&32!==a.patchFlag&&it.push(a),a}let ig=function(e,t=null,n=null,r=0,i=null,l=!1){var s;if(e&&e!==re||(e=r9),ic(e)){let r=iv(e,t,!0);return n&&ix(r,n),il>0&&!l&&it&&(6&r.shapeFlag?it[it.indexOf(e)]=r:it.push(r)),r.patchFlag=-2,r}if(I(s=e)&&"__vccOpts"in s&&(e=e.__vccOpts),t){let{class:e,style:n}=t=im(t);e&&!R(e)&&(t.class=ei(e)),M(n)&&(tg(n)&&!E(n)&&(n=T({},n)),t.style=Y(n))}let o=R(e)?1:rY(e)?128:e.__isTeleport?64:M(e)?4:2*!!I(e);return ip(e,t,n,r,i,o,l,!0)};function im(e){return e?tg(e)||rP(e)?T({},e):e:null}function iv(e,t,n=!1,r=!1){let{props:i,ref:l,patchFlag:s,children:o,transition:a}=e,c=t?iC(i||{},t):i,u={__v_isVNode:!0,__v_skip:!0,type:e.type,props:c,key:c&&id(c),ref:t&&t.ref?n&&l?E(l)?l.concat(ih(t)):[l,ih(t)]:ih(t):l,scopeId:e.scopeId,slotScopeIds:e.slotScopeIds,children:o,target:e.target,targetStart:e.targetStart,targetAnchor:e.targetAnchor,staticCount:e.staticCount,shapeFlag:e.shapeFlag,patchFlag:t&&e.type!==r8?-1===s?16:16|s:s,dynamicProps:e.dynamicProps,dynamicChildren:e.dynamicChildren,appContext:e.appContext,dirs:e.dirs,transition:a,component:e.component,suspense:e.suspense,ssContent:e.ssContent&&iv(e.ssContent),ssFallback:e.ssFallback&&iv(e.ssFallback),placeholder:e.placeholder,el:e.el,anchor:e.anchor,ctx:e.ctx,ce:e.ce};return a&&r&&nC(u,a.clone(u)),u}function iy(e=" ",t=0){return ig(r5,null,e,t)}function ib(e="",t=!1){return t?(ir(),ia(r9,null,e)):ig(r9,null,e)}function i_(e){return null==e||"boolean"==typeof e?ig(r9):E(e)?ig(r8,null,e.slice()):ic(e)?iS(e):ig(r5,null,String(e))}function iS(e){return null===e.el&&-1!==e.patchFlag||e.memo?e:iv(e)}function ix(e,t){let n=0,{shapeFlag:r}=e;if(null==t)t=null;else if(E(t))n=16;else if("object"==typeof t)if(65&r){let n=t.default;n&&(n._c&&(n._d=!1),ix(e,n()),n._c&&(n._d=!0));return}else{n=32;let r=t._;r||rP(t)?3===r&&t0&&(1===t0.slots._?t._=1:(t._=2,e.patchFlag|=1024)):t._ctx=t0}else if(I(t)){if(65&r)return void ix(e,{default:t});t={default:t,_ctx:t0},n=32}else t=String(t),64&r?(n=16,t=[iy(t)]):n=8;e.children=t,e.shapeFlag|=n}function iC(...e){let t={};for(let n=0;n<e.length;n++){let r=e[n];for(let e in r)if("class"===e)t.class!==r.class&&(t.class=ei([t.class,r.class]));else if("style"===e)t.style=Y([t.style,r.style]);else if(C(e)){let n=t[e],i=r[e];i&&n!==i&&!(E(n)&&n.includes(i))?t[e]=n?[].concat(n,i):i:null!=i||null!=n||k(e)||(t[e]=i)}else""!==e&&(t[e]=r[e])}return t}function ik(e,t,n,r=null){tD(e,t,7,[n,r])}let iT=r_(),iw=0,iN=null,iA=()=>iN||t0;c=e=>{iN=e},u=e=>{iO=e};let iE=e=>{let t=iN;return c(e),e.scope.on(),()=>{e.scope.off(),c(t)}},iI=()=>{iN&&iN.scope.off(),c(null)};function iR(e){return 4&e.vnode.shapeFlag}let iO=!1;function iM(e,t,n){I(t)?e.render=t:M(t)&&(e.setupState=tN(t)),iF(e,n)}function iP(e){d=e,h=e=>{e.render._rc&&(e.withProxy=new Proxy(e.ctx,ro))}}function iF(e,t,n){let r=e.type;if(!e.render){if(!t&&d&&!r.render){let t=r.template||rh(e).template;if(t){let{isCustomElement:n,compilerOptions:i}=e.appContext.config,{delimiters:l,compilerOptions:s}=r,o=T(T({isCustomElement:n,delimiters:l},i),s);r.render=d(t,o)}}e.render=r.render||S,h&&h(e)}{let t=iE(e);eE();try{!function(e){let t=rh(e),n=e.proxy,r=e.ctx;ru=!1,t.beforeCreate&&rd(t.beforeCreate,e,"bc");let{data:i,computed:l,methods:s,watch:o,provide:a,inject:c,created:u,beforeMount:d,mounted:h,beforeUpdate:p,updated:f,activated:g,deactivated:m,beforeUnmount:y,unmounted:b,render:_,renderTracked:x,renderTriggered:C,errorCaptured:k,serverPrefetch:T,expose:w,inheritAttrs:N,components:A,directives:O}=t;if(c&&function(e,t){for(let n in E(e)&&(e=rm(e)),e){let r,i=e[n];t_(r=M(i)?"default"in i?t8(i.from||n,i.default,!0):t8(i.from||n):t8(i))?Object.defineProperty(t,n,{enumerable:!0,configurable:!0,get:()=>r.value,set:e=>r.value=e}):t[n]=r}}(c,r),s)for(let e in s){let t=s[e];I(t)&&(r[e]=t.bind(n))}if(i){let t=i.call(n,n);M(t)&&(e.data=ta(t))}if(ru=!0,l)for(let e in l){let t=l[e],i=I(t)?t.bind(n,n):I(t.get)?t.get.bind(n,n):S,s=iB({get:i,set:!I(t)&&I(t.set)?t.set.bind(n):S});Object.defineProperty(r,e,{enumerable:!0,configurable:!0,get:()=>s.value,set:e=>s.value=e})}if(o)for(let e in o)!function e(t,n,r,i){let l=i.includes(".")?nt(r,i):()=>r[i];if(R(t)){let e=n[t];I(e)&&t7(l,e,void 0)}else if(I(t))t7(l,t.bind(r),void 0);else if(M(t))if(E(t))t.forEach(t=>e(t,n,r,i));else{let e=I(t.handler)?t.handler.bind(r):n[t.handler];I(e)&&t7(l,e,t)}}(o[e],r,n,e);if(a){let e=I(a)?a.call(n):a;Reflect.ownKeys(e).forEach(t=>{t4(t,e[t])})}function P(e,t){E(t)?t.forEach(t=>e(t.bind(n))):t&&e(t.bind(n))}if(u&&rd(u,e,"c"),P(nY,d),P(n0,h),P(n1,p),P(n2,f),P(nK,g),P(nz,m),P(n9,k),P(n5,x),P(n8,C),P(n6,y),P(n3,b),P(n4,T),E(w))if(w.length){let t=e.exposed||(e.exposed={});w.forEach(e=>{Object.defineProperty(t,e,{get:()=>n[e],set:t=>n[e]=t,enumerable:!0})})}else e.exposed||(e.exposed={});_&&e.render===S&&(e.render=_),null!=N&&(e.inheritAttrs=N),A&&(e.components=A),O&&(e.directives=O)}(e)}finally{eI(),t()}}}let iL={get:(e,t)=>(eV(e,"get",""),e[t])};function i$(e){return{attrs:new Proxy(e.attrs,iL),slots:e.slots,emit:e.emit,expose:t=>{e.exposed=t||{}}}}function iD(e){return e.exposed?e.exposeProxy||(e.exposeProxy=new Proxy(tN(tv(e.exposed)),{get:(t,n)=>n in t?t[n]:n in ri?ri[n](e):void 0,has:(e,t)=>t in e||t in ri})):e.proxy}function iV(e,t=!0){return I(e)?e.displayName||e.name:e.name||t&&e.__name}let iB=(e,t)=>(function(e,t=!1){let n,r;return I(e)?n=e:(n=e.get,r=e.set),new tO(n,r,t)})(e,iO);function ij(e,t,n){try{is(-1);let r=arguments.length;if(2!==r)return r>3?n=Array.prototype.slice.call(arguments,2):3===r&&ic(n)&&(n=[n]),ig(e,t,n);if(!M(t)||E(t))return ig(e,null,t);if(ic(t))return ig(e,null,[t]);return ig(e,t)}finally{is(1)}}function iU(e,t){let n=e.memo;if(n.length!=t.length)return!1;for(let e=0;e<n.length;e++)if(K(n[e],t[e]))return!1;return il>0&&it&&it.push(e),!0}let iH="3.5.39",iq="u">typeof window&&window.trustedTypes;if(iq)try{m=iq.createPolicy("vue",{createHTML:e=>e})}catch(e){}let iW=m?e=>m.createHTML(e):e=>e,iK="u">typeof document?document:null,iz=iK&&iK.createElement("template"),iJ={insert:(e,t,n)=>{t.insertBefore(e,n||null)},remove:e=>{let t=e.parentNode;t&&t.removeChild(e)},createElement:(e,t,n,r)=>{let i="svg"===t?iK.createElementNS("http://www.w3.org/2000/svg",e):"mathml"===t?iK.createElementNS("http://www.w3.org/1998/Math/MathML",e):n?iK.createElement(e,{is:n}):iK.createElement(e);return"select"===e&&r&&null!=r.multiple&&i.setAttribute("multiple",r.multiple),i},createText:e=>iK.createTextNode(e),createComment:e=>iK.createComment(e),setText:(e,t)=>{e.nodeValue=t},setElementText:(e,t)=>{e.textContent=t},parentNode:e=>e.parentNode,nextSibling:e=>e.nextSibling,querySelector:e=>iK.querySelector(e),setScopeId(e,t){e.setAttribute(t,"")},insertStaticContent(e,t,n,r,i,l){let s=n?n.previousSibling:t.lastChild;if(i&&(i===l||i.nextSibling))for(;t.insertBefore(i.cloneNode(!0),n),i!==l&&(i=i.nextSibling););else{iz.innerHTML=iW("svg"===r?`<svg>${e}</svg>`:"mathml"===r?`<math>${e}</math>`:e);let i=iz.content;if("svg"===r||"mathml"===r){let e=i.firstChild;for(;e.firstChild;)i.appendChild(e.firstChild);i.removeChild(e)}t.insertBefore(i,n)}return[s?s.nextSibling:t.firstChild,n?n.previousSibling:t.lastChild]}},iG="transition",iX="animation",iQ=Symbol("_vtc"),iZ={name:String,type:String,css:{type:Boolean,default:!0},duration:[String,Number,Object],enterFromClass:String,enterActiveClass:String,enterToClass:String,appearFromClass:String,appearActiveClass:String,appearToClass:String,leaveFromClass:String,leaveActiveClass:String,leaveToClass:String},iY=T({},ng,iZ),i0=((t=(e,{slots:t})=>ij(ny,i6(e),t)).displayName="Transition",t.props=iY,t),i1=(e,t=[])=>{E(e)?e.forEach(e=>e(...t)):e&&e(...t)},i2=e=>!!e&&(E(e)?e.some(e=>e.length>1):e.length>1);function i6(e){let t={};for(let n in e)n in iZ||(t[n]=e[n]);if(!1===e.css)return t;let{name:n="v",type:r,duration:i,enterFromClass:l=`${n}-enter-from`,enterActiveClass:s=`${n}-enter-active`,enterToClass:o=`${n}-enter-to`,appearFromClass:a=l,appearActiveClass:c=s,appearToClass:u=o,leaveFromClass:d=`${n}-leave-from`,leaveActiveClass:h=`${n}-leave-active`,leaveToClass:p=`${n}-leave-to`}=e,f=function(e){if(null==e)return null;{if(M(e))return[function(e){return X(e)}(e.enter),function(e){return X(e)}(e.leave)];let t=function(e){return X(e)}(e);return[t,t]}}(i),g=f&&f[0],m=f&&f[1],{onBeforeEnter:y,onEnter:b,onEnterCancelled:_,onLeave:S,onLeaveCancelled:x,onBeforeAppear:C=y,onAppear:k=b,onAppearCancelled:w=_}=t,N=(e,t,n,r)=>{e._enterCancelled=r,i4(e,t?u:o),i4(e,t?c:s),n&&n()},A=(e,t)=>{e._isLeaving=!1,i4(e,d),i4(e,p),i4(e,h),t&&t()},E=e=>(t,n)=>{let i=e?k:b,s=()=>N(t,e,n);i1(i,[t,s]),i8(()=>{i4(t,e?a:l),i3(t,e?u:o),i2(i)||i9(t,r,g,s)})};return T(t,{onBeforeEnter(e){i1(y,[e]),i3(e,l),i3(e,s)},onBeforeAppear(e){i1(C,[e]),i3(e,a),i3(e,c)},onEnter:E(!1),onAppear:E(!0),onLeave(e,t){e._isLeaving=!0;let n=()=>A(e,t);i3(e,d),e._enterCancelled?(i3(e,h),ln(e)):(ln(e),i3(e,h)),i8(()=>{e._isLeaving&&(i4(e,d),i3(e,p),i2(S)||i9(e,r,m,n))}),i1(S,[e,n])},onEnterCancelled(e){N(e,!1,void 0,!0),i1(_,[e])},onAppearCancelled(e){N(e,!0,void 0,!0),i1(w,[e])},onLeaveCancelled(e){A(e),i1(x,[e])}})}function i3(e,t){t.split(/\s+/).forEach(t=>t&&e.classList.add(t)),(e[iQ]||(e[iQ]=new Set)).add(t)}function i4(e,t){t.split(/\s+/).forEach(t=>t&&e.classList.remove(t));let n=e[iQ];n&&(n.delete(t),n.size||(e[iQ]=void 0))}function i8(e){requestAnimationFrame(()=>{requestAnimationFrame(e)})}let i5=0;function i9(e,t,n,r){let i=e._endId=++i5,l=()=>{i===e._endId&&r()};if(null!=n)return setTimeout(l,n);let{type:s,timeout:o,propCount:a}=i7(e,t);if(!s)return r();let c=s+"end",u=0,d=()=>{e.removeEventListener(c,h),l()},h=t=>{t.target===e&&++u>=a&&d()};setTimeout(()=>{u<a&&d()},o+1),e.addEventListener(c,h)}function i7(e,t){let n=window.getComputedStyle(e),r=e=>(n[e]||"").split(", "),i=r(`${iG}Delay`),l=r(`${iG}Duration`),s=le(i,l),o=r(`${iX}Delay`),a=r(`${iX}Duration`),c=le(o,a),u=null,d=0,h=0;t===iG?s>0&&(u=iG,d=s,h=l.length):t===iX?c>0&&(u=iX,d=c,h=a.length):h=(u=(d=Math.max(s,c))>0?s>c?iG:iX:null)?u===iG?l.length:a.length:0;let p=u===iG&&/\b(?:transform|all)(?:,|$)/.test(r(`${iG}Property`).toString());return{type:u,timeout:d,propCount:h,hasTransform:p}}function le(e,t){for(;e.length<t.length;)e=e.concat(e);return Math.max(...t.map((t,n)=>lt(t)+lt(e[n])))}function lt(e){return"auto"===e?0:1e3*Number(e.slice(0,-1).replace(",","."))}function ln(e){return(e?e.ownerDocument:document).body.offsetHeight}let lr=Symbol("_vod"),li=Symbol("_vsh");function ll(e,t){e.style.display=t?e[lr]:"none",e[li]=!t}let ls=Symbol("");function lo(e,t){if(1===e.nodeType){let r=e.style,i="";for(let e in t){var n;let l=null==(n=t[e])?"initial":"string"==typeof n?""===n?" ":n:String(n);r.setProperty(`--${e}`,l),i+=`--${e}: ${l};`}r[ls]=i}}let la=/(?:^|;)\s*display\s*:/,lc=/\s*!important$/;function lu(e,t,n){if(E(n))n.forEach(n=>lu(e,t,n));else if(null==n&&(n=""),t.startsWith("--"))e.setProperty(t,n);else{let r=function(e,t){let n=lh[t];if(n)return n;let r=j(t);if("filter"!==r&&r in e)return lh[t]=r;r=q(r);for(let n=0;n<ld.length;n++){let i=ld[n]+r;if(i in e)return lh[t]=i}return t}(e,t);lc.test(n)?e.setProperty(H(r),n.replace(lc,""),"important"):e[r]=n}}let ld=["Webkit","Moz","ms"],lh={},lp="http://www.w3.org/1999/xlink";function lf(e,t,n,r,i,l=ec(t)){if(r&&t.startsWith("xlink:"))null==n?e.removeAttributeNS(lp,t.slice(6,t.length)):e.setAttributeNS(lp,t,n);else null==n||l&&!(n||""===n)?e.removeAttribute(t):e.setAttribute(t,l?"":O(n)?String(n):n)}function lg(e,t,n,r,i){if("innerHTML"===t||"textContent"===t){null!=n&&(e[t]="innerHTML"===t?iW(n):n);return}let l=e.tagName;if("value"===t&&"PROGRESS"!==l&&!l.includes("-")){let r="OPTION"===l?e.getAttribute("value")||"":e.value,i=null==n?"checkbox"===e.type?"on":"":String(n);r===i&&"_value"in e||(e.value=i),null==n&&e.removeAttribute(t),e._value=n;return}let s=!1;if(""===n||null==n){let r=typeof e[t];if("boolean"===r){var o;n=!!(o=n)||""===o}else null==n&&"string"===r?(n="",s=!0):"number"===r&&(n=0,s=!0)}try{e[t]=n}catch(e){}s&&e.removeAttribute(i||t)}function lm(e,t,n,r){e.addEventListener(t,n,r)}let lv=Symbol("_vei"),ly=/(Once|Passive|Capture)$/,lb=/^on:?(?:Once|Passive|Capture)$/,l_=0,lS=Promise.resolve(),lx=e=>111===e.charCodeAt(0)&&110===e.charCodeAt(1)&&e.charCodeAt(2)>96&&123>e.charCodeAt(2),lC=(e,t,n,r,i,l)=>{let s="svg"===i;if("class"===t){var o;let t;o=r,(t=e[iQ])&&(o=(o?[o,...t]:[...t]).join(" ")),null==o?e.removeAttribute("class"):s?e.setAttribute("class",o):e.className=o}else"style"===t?function(e,t,n){let r=e.style,i=R(n),l=!1;if(n&&!i){if(t)if(R(t))for(let e of t.split(";")){let t=e.slice(0,e.indexOf(":")).trim();null==n[t]&&lu(r,t,"")}else for(let e in t)null==n[e]&&lu(r,e,"");for(let i in n){var s,o,a,c;"display"===i&&(l=!0);let u=n[i];null!=u?(s=e,o=i,a=!R(t)&&t?t[i]:void 0,c=u,"TEXTAREA"===s.tagName&&("width"===o||"height"===o)&&R(c)&&a===c||lu(r,i,u)):lu(r,i,"")}}else if(i){if(t!==n){let e=r[ls];e&&(n+=";"+e),r.cssText=n,l=la.test(n)}}else t&&e.removeAttribute("style");lr in e&&(e[lr]=l?r.display:"",e[li]&&(r.display="none"))}(e,n,r):C(t)?k(t)||function(e,t,n,r=null){let i=e[lv]||(e[lv]={}),l=i[t];if(n&&l)l.value=n;else{let[a,c]=function(e){let t,n;for(;(n=e.match(ly))&&!lb.test(e);)t||(t={}),e=e.slice(0,e.length-n[1].length),t[n[1].toLowerCase()]=!0;return[":"===e[2]?e.slice(3):H(e.slice(2)),t]}(t);if(n){var s,o;let l;lm(e,a,i[t]=(s=n,o=r,(l=e=>{if(e._vts){if(e._vts<=l.attached)return}else e._vts=Date.now();let t=l.value;if(E(t)){let n=e.stopImmediatePropagation;e.stopImmediatePropagation=()=>{n.call(e),e._stopped=!0};let r=t.slice(),i=[e];for(let t=0;t<r.length&&!e._stopped;t++){let e=r[t];e&&tD(e,o,5,i)}}else tD(t,o,5,[e])}).value=s,l.attached=l_||(lS.then(()=>l_=0),l_=Date.now()),l),c)}else l&&(e.removeEventListener(a,l,c),i[t]=void 0)}}(e,t,r,l):("."===t[0]?(t=t.slice(1),0):"^"===t[0]?(t=t.slice(1),1):!function(e,t,n,r){if(r)return!!("innerHTML"===t||"textContent"===t||t in e&&lx(t)&&I(n));if("spellcheck"===t||"draggable"===t||"translate"===t||"autocorrect"===t||"sandbox"===t&&"IFRAME"===e.tagName||"form"===t||"list"===t&&"INPUT"===e.tagName||"type"===t&&"TEXTAREA"===e.tagName)return!1;if("width"===t||"height"===t){let t=e.tagName;if("IMG"===t||"VIDEO"===t||"CANVAS"===t||"SOURCE"===t)return!1}return!(lx(t)&&R(n))&&t in e}(e,t,r,s))?e._isVueCE&&(function(e,t){let n=e._def.props;if(!n)return!1;let r=j(t);return Array.isArray(n)?n.some(e=>j(e)===r):Object.keys(n).some(e=>j(e)===r)}(e,t)||e._def.__asyncLoader&&(/[A-Z]/.test(t)||!R(r)))?lg(e,j(t),r,l,t):("true-value"===t?e._trueValue=r:"false-value"===t&&(e._falseValue=r),lf(e,t,r,s)):(lg(e,t,r),e.tagName.includes("-")||"value"!==t&&"checked"!==t&&"selected"!==t||lf(e,t,r,s,l,"value"!==t))},lk={};function lT(e,t,n){let r,i=nT(e,t);"[object Object]"===(r=i,F.call(r))&&(i=T({},i,t));class l extends lN{constructor(e){super(i,e,n)}}return l.def=i,l}let lw="u">typeof HTMLElement?HTMLElement:class{};class lN extends lw{constructor(e,t={},n=l4){super(),this._def=e,this._props=t,this._createApp=n,this._isVueCE=!0,this._instance=null,this._app=null,this._nonce=this._def.nonce,this._connected=!1,this._resolved=!1,this._patching=!1,this._dirty=!1,this._numberProps=null,this._styleChildren=new WeakSet,this._styleAnchors=new WeakMap,this._ob=null,this.shadowRoot&&n!==l4?this._root=this.shadowRoot:!1!==e.shadowRoot?(this.attachShadow(T({},e.shadowRootOptions,{mode:"open"})),this._root=this.shadowRoot):this._root=this}connectedCallback(){if(!this.isConnected)return;this.shadowRoot||this._resolved||this._parseSlots(),this._connected=!0;let e=this;for(;e=e&&(e.assignedSlot||e.parentNode||e.host);)if(e instanceof lN){this._parent=e;break}this._instance||(this._resolved?this._mount(this._def):e&&e._pendingResolve?this._pendingResolve=e._pendingResolve.then(()=>{this._pendingResolve=void 0,this._resolveDef()}):this._resolveDef())}_setParent(e=this._parent){e&&(this._instance.parent=e._instance,this._inheritParentContext(e))}_inheritParentContext(e=this._parent){e&&this._app&&Object.setPrototypeOf(this._app._context.provides,e._instance.provides)}disconnectedCallback(){this._connected=!1,tz(()=>{!this._connected&&(this._ob&&(this._ob.disconnect(),this._ob=null),this._app&&this._app.unmount(),this._instance&&(this._instance.ce=void 0),this._app=this._instance=null,this._teleportTargets&&(this._teleportTargets.clear(),this._teleportTargets=void 0))})}_processMutations(e){for(let t of e)this._setAttr(t.attributeName)}_resolveDef(){if(this._pendingResolve)return;for(let e=0;e<this.attributes.length;e++)this._setAttr(this.attributes[e].name);this._ob=new MutationObserver(this._processMutations.bind(this)),this._ob.observe(this,{attributes:!0});let e=(e,t=!1)=>{let n;this._resolved=!0,this._pendingResolve=void 0;let{props:r,styles:i}=e;if(r&&!E(r))for(let e in r){let t=r[e];(t===Number||t&&t.type===Number)&&(e in this._props&&(this._props[e]=X(this._props[e])),(n||(n=Object.create(null)))[j(e)]=!0)}this._numberProps=n,this._resolveProps(e),this.shadowRoot&&this._applyStyles(i),this._mount(e)},t=this._def.__asyncLoader;t?this._pendingResolve=t().then(t=>{t.configureApp=this._def.configureApp,e(this._def=t,!0)}):e(this._def)}_mount(e){this._app=this._createApp(e),this._inheritParentContext(),e.configureApp&&e.configureApp(this._app),this._app._ceVNode=this._createVNode(),this._app.mount(this._root);let t=this._instance&&this._instance.exposed;if(t)for(let e in t)A(this,e)||Object.defineProperty(this,e,{get:()=>tT(t[e])})}_resolveProps(e){let{props:t}=e,n=E(t)?t:Object.keys(t||{});for(let e of Object.keys(this))"_"!==e[0]&&n.includes(e)&&this._setProp(e,this[e]);for(let e of n.map(j))Object.defineProperty(this,e,{get(){return this._getProp(e)},set(t){this._setProp(e,t,!0,!this._patching)}})}_setAttr(e){if(e.startsWith("data-v-"))return;let t=this.hasAttribute(e),n=t?this.getAttribute(e):lk,r=j(e);t&&this._numberProps&&this._numberProps[r]&&(n=X(n)),this._setProp(r,n,!1,!0)}_getProp(e){return this._props[e]}_setProp(e,t,n=!0,r=!1){if(t!==this._props[e]&&(this._dirty=!0,t===lk?delete this._props[e]:(this._props[e]=t,"key"===e&&this._app&&(this._app._ceVNode.key=t)),r&&this._instance&&this._update(),n)){let n=this._ob;n&&(this._processMutations(n.takeRecords()),n.disconnect()),!0===t?this.setAttribute(H(e),""):"string"==typeof t||"number"==typeof t?this.setAttribute(H(e),t+""):t||this.removeAttribute(H(e)),n&&n.observe(this,{attributes:!0})}}_update(){let e=this._createVNode();this._app&&(e.appContext=this._app._context),l3(e,this._root)}_createVNode(){let e={};this.shadowRoot||(e.onVnodeMounted=e.onVnodeUpdated=this._renderSlots.bind(this));let t=ig(this._def,T(e,this._props));return this._instance||(t.ce=e=>{this._instance=e,e.ce=this,e.isCE=!0;let t=(e,t)=>{let n;this.dispatchEvent(new CustomEvent(e,"[object Object]"===(n=t[0],F.call(n))?T({detail:t},t[0]):{detail:t}))};e.emit=(e,...n)=>{t(e,n),H(e)!==e&&t(H(e),n)},this._setParent()}),t}_applyStyles(e,t,n){if(!e)return;if(t){if(t===this._def||this._styleChildren.has(t))return;this._styleChildren.add(t)}let r=this._nonce,i=this.shadowRoot,l=n?this._getStyleAnchor(n)||this._getStyleAnchor(this._def):this._getRootStyleInsertionAnchor(i),s=null;for(let o=e.length-1;o>=0;o--){let a=document.createElement("style");r&&a.setAttribute("nonce",r),a.textContent=e[o],i.insertBefore(a,s||l),s=a,0===o&&(n||this._styleAnchors.set(this._def,a),t&&this._styleAnchors.set(t,a))}}_getStyleAnchor(e){if(!e)return null;let t=this._styleAnchors.get(e);return t&&t.parentNode===this.shadowRoot?t:(t&&this._styleAnchors.delete(e),null)}_getRootStyleInsertionAnchor(e){for(let t=0;t<e.childNodes.length;t++){let n=e.childNodes[t];if(!(n instanceof HTMLStyleElement))return n}return null}_parseSlots(){let e,t=this._slots={};for(;e=this.firstChild;){let n=1===e.nodeType&&e.getAttribute("slot")||"default";(t[n]||(t[n]=[])).push(e),this.removeChild(e)}}_renderSlots(){let e=this._getSlots(),t=this._instance.type.__scopeId;for(let n=0;n<e.length;n++){let r=e[n],i=r.getAttribute("name")||"default",l=this._slots[i],s=r.parentNode;if(l)for(let e of l){if(t&&1===e.nodeType){let n,r=t+"-s",i=document.createTreeWalker(e,1);for(e.setAttribute(r,"");n=i.nextNode();)n.setAttribute(r,"")}s.insertBefore(e,r)}else for(;r.firstChild;)s.insertBefore(r.firstChild,r);s.removeChild(r)}}_getSlots(){let e=[this];this._teleportTargets&&e.push(...this._teleportTargets);let t=new Set;for(let n of e){let e=n.querySelectorAll("slot");for(let n=0;n<e.length;n++)t.add(e[n])}return Array.from(t)}_injectChildStyle(e,t){this._applyStyles(e.styles,e,t)}_beginPatch(){this._patching=!0,this._dirty=!1}_endPatch(){this._patching=!1,this._dirty&&this._instance&&this._update()}_hasShadowRoot(){return!1!==this._def.shadowRoot}_removeChildStyle(e){}}function lA(e){let t=iA(),n=t&&t.ce;return n||null}let lE=new WeakMap,lI=new WeakMap,lR=Symbol("_moveCb"),lO=Symbol("_enterCb"),lM=(n={name:"TransitionGroup",props:T({},iY,{tag:String,moveClass:String}),setup(e,{slots:t}){let n,r,i=iA(),l=np();return n2(()=>{if(!n.length)return;let t=e.moveClass||`${e.name||"v"}-move`;if(!function(e,t,n){let r=e.cloneNode(),i=e[iQ];i&&i.forEach(e=>{e.split(/\s+/).forEach(e=>e&&r.classList.remove(e))}),n.split(/\s+/).forEach(e=>e&&r.classList.add(e)),r.style.display="none";let l=1===t.nodeType?t:t.parentNode;l.appendChild(r);let{hasTransform:s}=i7(r);return l.removeChild(r),s}(n[0].el,i.vnode.el,t)){n=[];return}n.forEach(lP),n.forEach(lF);let r=n.filter(lL);ln(i.vnode.el),r.forEach(e=>{let n=e.el,r=n.style;i3(n,t),r.transform=r.webkitTransform=r.transitionDuration="";let i=n[lR]=e=>{(!e||e.target===n)&&(!e||e.propertyName.endsWith("transform"))&&(n.removeEventListener("transitionend",i),n[lR]=null,i4(n,t))};n.addEventListener("transitionend",i)}),n=[]}),()=>{let s=tm(e),o=i6(s),a=s.tag||r8;if(n=[],r)for(let e=0;e<r.length;e++){let t=r[e];t.el&&t.el instanceof Element&&!t.el[li]&&(n.push(t),nC(t,n_(t,o,l,i)),lE.set(t,l$(t.el)))}r=t.default?nk(t.default()):[];for(let e=0;e<r.length;e++){let t=r[e];null!=t.key&&nC(t,n_(t,o,l,i))}return ig(a,null,r)}}},delete n.props.mode,n);function lP(e){let t=e.el;t[lR]&&t[lR](),t[lO]&&t[lO]()}function lF(e){lI.set(e,l$(e.el))}function lL(e){let t=lE.get(e),n=lI.get(e),r=t.left-n.left,i=t.top-n.top;if(r||i){let t=e.el,n=t.style,l=t.getBoundingClientRect(),s=1,o=1;return t.offsetWidth&&(s=l.width/t.offsetWidth),t.offsetHeight&&(o=l.height/t.offsetHeight),Number.isFinite(s)&&0!==s||(s=1),Number.isFinite(o)&&0!==o||(o=1),.01>Math.abs(s-1)&&(s=1),.01>Math.abs(o-1)&&(o=1),n.transform=n.webkitTransform=`translate(${r/s}px,${i/o}px)`,n.transitionDuration="0s",e}}function l$(e){let t=e.getBoundingClientRect();return{left:t.left,top:t.top}}let lD=e=>{let t=e.props["onUpdate:modelValue"]||!1;return E(t)?e=>z(t,e):t};function lV(e){e.target.composing=!0}function lB(e){let t=e.target;t.composing&&(t.composing=!1,t.dispatchEvent(new Event("input")))}let lj=Symbol("_assign");function lU(e,t,n){return t&&(e=e.trim()),n&&(e=G(e)),e}let lH={created(e,{modifiers:{lazy:t,trim:n,number:r}},i){e[lj]=lD(i);let l=r||i.props&&"number"===i.props.type;lm(e,t?"change":"input",t=>{t.target.composing||e[lj](lU(e.value,n,l))}),(n||l)&&lm(e,"change",()=>{e.value=lU(e.value,n,l)}),t||(lm(e,"compositionstart",lV),lm(e,"compositionend",lB),lm(e,"change",lB))},mounted(e,{value:t}){e.value=null==t?"":t},beforeUpdate(e,{value:t,oldValue:n,modifiers:{lazy:r,trim:i,number:l}},s){if(e[lj]=lD(s),e.composing)return;let o=(l||"number"===e.type)&&!/^0\d/.test(e.value)?G(e.value):e.value,a=null==t?"":t;if(o===a)return;let c=e.getRootNode();(c instanceof Document||c instanceof ShadowRoot)&&c.activeElement===e&&"range"!==e.type&&(r&&t===n||i&&e.value.trim()===a)||(e.value=a)}},lq={deep:!0,created(e,t,n){e[lj]=lD(n),lm(e,"change",()=>{let t=e._modelValue,n=lG(e),r=e.checked,i=e[lj];if(E(t)){let e=ed(t,n),l=-1!==e;if(r&&!l)i(t.concat(n));else if(!r&&l){let n=[...t];n.splice(e,1),i(n)}}else{let l;if("[object Set]"===(l=t,F.call(l))){let e=new Set(t);r?e.add(n):e.delete(n),i(e)}else i(lX(e,r))}})},mounted:lW,beforeUpdate(e,t,n){e[lj]=lD(n),lW(e,t,n)}};function lW(e,{value:t,oldValue:n},r){let i;if(e._modelValue=t,E(t))i=ed(t,r.props.value)>-1;else{let l;if("[object Set]"===(l=t,F.call(l)))i=t.has(r.props.value);else{if(t===n)return;i=eu(t,lX(e,!0))}}e.checked!==i&&(e.checked=i)}let lK={created(e,{value:t},n){e.checked=eu(t,n.props.value),e[lj]=lD(n),lm(e,"change",()=>{e[lj](lG(e))})},beforeUpdate(e,{value:t,oldValue:n},r){e[lj]=lD(r),t!==n&&(e.checked=eu(t,r.props.value))}},lz={deep:!0,created(e,{value:t,modifiers:{number:n}},r){let i,l="[object Set]"===(i=t,F.call(i));lm(e,"change",()=>{let t=Array.prototype.filter.call(e.options,e=>e.selected).map(e=>n?G(lG(e)):lG(e));e[lj](e.multiple?l?new Set(t):t:t[0]),e._assigning=!0,tz(()=>{e._assigning=!1})}),e[lj]=lD(r)},mounted(e,{value:t}){lJ(e,t)},beforeUpdate(e,t,n){e[lj]=lD(n)},updated(e,{value:t}){e._assigning||lJ(e,t)}};function lJ(e,t){let n,r=e.multiple,i=E(t);if(!r||i||"[object Set]"===(n=t,F.call(n))){for(let n=0,l=e.options.length;n<l;n++){let l=e.options[n],s=lG(l);if(r)if(i){let e=typeof s;"string"===e||"number"===e?l.selected=t.some(e=>String(e)===String(s)):l.selected=ed(t,s)>-1}else l.selected=t.has(s);else if(eu(lG(l),t)){e.selectedIndex!==n&&(e.selectedIndex=n);return}}r||-1===e.selectedIndex||(e.selectedIndex=-1)}}function lG(e){return"_value"in e?e._value:e.value}function lX(e,t){let n=t?"_trueValue":"_falseValue";return n in e?e[n]:t}function lQ(e,t,n,r,i){let l=function(e,t){switch(e){case"SELECT":return lz;case"TEXTAREA":return lH;default:switch(t){case"checkbox":return lq;case"radio":return lK;default:return lH}}}(e.tagName,n.props&&n.props.type)[i];l&&l(e,t,n,r)}let lZ=["ctrl","shift","alt","meta"],lY={stop:e=>e.stopPropagation(),prevent:e=>e.preventDefault(),self:e=>e.target!==e.currentTarget,ctrl:e=>!e.ctrlKey,shift:e=>!e.shiftKey,alt:e=>!e.altKey,meta:e=>!e.metaKey,left:e=>"button"in e&&0!==e.button,middle:e=>"button"in e&&1!==e.button,right:e=>"button"in e&&2!==e.button,exact:(e,t)=>lZ.some(n=>e[`${n}Key`]&&!t.includes(n))},l0={esc:"escape",space:" ",up:"arrow-up",left:"arrow-left",right:"arrow-right",down:"arrow-down",delete:"backspace"},l1=T({patchProp:lC},iJ),l2=!1;function l6(){return p=l2?p:rK(l1),l2=!0,p}let l3=(...e)=>{(p||(p=rz(l1))).render(...e)},l4=(...e)=>{let t=(p||(p=rz(l1))).createApp(...e),{mount:n}=t;return t.mount=e=>{let r=l9(e);if(!r)return;let i=t._component;I(i)||i.render||i.template||(i.template=r.innerHTML),1===r.nodeType&&(r.textContent="");let l=n(r,!1,l5(r));return r instanceof Element&&(r.removeAttribute("v-cloak"),r.setAttribute("data-v-app","")),l},t},l8=(...e)=>{let t=l6().createApp(...e),{mount:n}=t;return t.mount=e=>{let t=l9(e);if(t)return n(t,!0,l5(t))},t};function l5(e){return e instanceof SVGElement?"svg":"function"==typeof MathMLElement&&e instanceof MathMLElement?"mathml":void 0}function l9(e){return R(e)?document.querySelector(e):e}let l7=Symbol(""),se=Symbol(""),st=Symbol(""),sn=Symbol(""),sr=Symbol(""),si=Symbol(""),sl=Symbol(""),ss=Symbol(""),so=Symbol(""),sa=Symbol(""),sc=Symbol(""),su=Symbol(""),sd=Symbol(""),sh=Symbol(""),sp=Symbol(""),sf=Symbol(""),sg=Symbol(""),sm=Symbol(""),sv=Symbol(""),sy=Symbol(""),sb=Symbol(""),s_=Symbol(""),sS=Symbol(""),sx=Symbol(""),sC=Symbol(""),sk=Symbol(""),sT=Symbol(""),sw=Symbol(""),sN=Symbol(""),sA=Symbol(""),sE=Symbol(""),sI=Symbol(""),sR=Symbol(""),sO=Symbol(""),sM=Symbol(""),sP=Symbol(""),sF=Symbol(""),sL=Symbol(""),s$=Symbol(""),sD={[l7]:"Fragment",[se]:"Teleport",[st]:"Suspense",[sn]:"KeepAlive",[sr]:"BaseTransition",[si]:"openBlock",[sl]:"createBlock",[ss]:"createElementBlock",[so]:"createVNode",[sa]:"createElementVNode",[sc]:"createCommentVNode",[su]:"createTextVNode",[sd]:"createStaticVNode",[sh]:"resolveComponent",[sp]:"resolveDynamicComponent",[sf]:"resolveDirective",[sg]:"resolveFilter",[sm]:"withDirectives",[sv]:"renderList",[sy]:"renderSlot",[sb]:"createSlots",[s_]:"toDisplayString",[sS]:"mergeProps",[sx]:"normalizeClass",[sC]:"normalizeStyle",[sk]:"normalizeProps",[sT]:"guardReactiveProps",[sw]:"toHandlers",[sN]:"camelize",[sA]:"capitalize",[sE]:"toHandlerKey",[sI]:"setBlockTracking",[sR]:"pushScopeId",[sO]:"popScopeId",[sM]:"withCtx",[sP]:"unref",[sF]:"isRef",[sL]:"withMemo",[s$]:"isMemoSame"},sV={start:{line:1,column:1,offset:0},end:{line:1,column:1,offset:0},source:""};function sB(e,t,n,r,i,l,s,o=!1,a=!1,c=!1,u=sV){var d,h,p,f;return e&&(o?(e.helper(si),e.helper((d=e.inSSR,h=c,d||h?sl:ss))):e.helper((p=e.inSSR,f=c,p||f?so:sa)),s&&e.helper(sm)),{type:13,tag:t,props:n,children:r,patchFlag:i,dynamicProps:l,directives:s,isBlock:o,disableTracking:a,isComponent:c,loc:u}}function sj(e,t=sV){return{type:17,loc:t,elements:e}}function sU(e,t=sV){return{type:15,loc:t,properties:e}}function sH(e,t){return{type:16,loc:sV,key:R(e)?sq(e,!0):e,value:t}}function sq(e,t=!1,n=sV,r=0){return{type:4,loc:n,content:e,isStatic:t,constType:t?3:r}}function sW(e,t=sV){return{type:8,loc:t,children:e}}function sK(e,t=[],n=sV){return{type:14,loc:n,callee:e,arguments:t}}function sz(e,t,n=!1,r=!1,i=sV){return{type:18,params:e,returns:t,newline:n,isSlot:r,loc:i}}function sJ(e,t,n,r=!0){return{type:19,test:e,consequent:t,alternate:n,newline:r,loc:sV}}function sG(e,{helper:t,removeHelper:n,inSSR:r}){if(!e.isBlock){var i,l;e.isBlock=!0,n((i=e.isComponent,r||i?so:sa)),t(si),t((l=e.isComponent,r||l?sl:ss))}}let sX=new Uint8Array([123,123]),sQ=new Uint8Array([125,125]);function sZ(e){return e>=97&&e<=122||e>=65&&e<=90}function sY(e){return 32===e||10===e||9===e||12===e||13===e}function s0(e){return 47===e||62===e||sY(e)}function s1(e){let t=new Uint8Array(e.length);for(let n=0;n<e.length;n++)t[n]=e.charCodeAt(n);return t}let s2={Cdata:new Uint8Array([67,68,65,84,65,91]),CdataEnd:new Uint8Array([93,93,62]),CommentEnd:new Uint8Array([45,45,62]),ScriptEnd:new Uint8Array([60,47,115,99,114,105,112,116]),StyleEnd:new Uint8Array([60,47,115,116,121,108,101]),TitleEnd:new Uint8Array([60,47,116,105,116,108,101]),TextareaEnd:new Uint8Array([60,47,116,101,120,116,97,114,101,97])};function s6(e){throw e}function s3(e){}function s4(e,t,n,r){let i=SyntaxError(String(`https://vuejs.org/error-reference/#compiler-${e}`));return i.code=e,i.loc=t,i}let s8=e=>4===e.type&&e.isStatic;function s5(e){switch(e){case"Teleport":case"teleport":return se;case"Suspense":case"suspense":return st;case"KeepAlive":case"keep-alive":return sn;case"BaseTransition":case"base-transition":return sr}}let s9=/^$|^\d|[^\$\w\xA0-\uFFFF]/,s7=/[A-Za-z_$\xA0-\uFFFF]/,oe=/[\.\?\w$\xA0-\uFFFF]/,ot=/\s+[.[]\s*|\s*[.[]\s+/g,on=e=>4===e.type?e.content:e.loc.source,or=e=>{let t=on(e).trim().replace(ot,e=>e.trim()),n=0,r=[],i=0,l=0,s=null;for(let e=0;e<t.length;e++){let o=t.charAt(e);switch(n){case 0:if("["===o)r.push(n),n=1,i++;else if("("===o)r.push(n),n=2,l++;else if(!(0===e?s7:oe).test(o))return!1;break;case 1:"'"===o||'"'===o||"`"===o?(r.push(n),n=3,s=o):"["===o?i++:"]"!==o||--i||(n=r.pop());break;case 2:if("'"===o||'"'===o||"`"===o)r.push(n),n=3,s=o;else if("("===o)l++;else if(")"===o){if(e===t.length-1)return!1;--l||(n=r.pop())}break;case 3:o===s&&(n=r.pop(),s=null)}}return!i&&!l},oi=/^\s*(?:async\s*)?(?:\([^)]*?\)|[\w$_]+)\s*(?::[^=]+)?=>|^\s*(?:async\s+)?function(?:\s+[\w$]+)?\s*\(/;function ol(e,t,n=!1){for(let r=0;r<e.props.length;r++){let i=e.props[r];if(7===i.type&&(n||i.exp)&&(R(t)?i.name===t:t.test(i.name)))return i}}function os(e,t,n=!1,r=!1){for(let i=0;i<e.props.length;i++){let l=e.props[i];if(6===l.type){if(n)continue;if(l.name===t&&(l.value||r))return l}else if("bind"===l.name&&(l.exp||r)&&oo(l.arg,t))return l}}function oo(e,t){return!!(e&&s8(e)&&e.content===t)}function oa(e){return 5===e.type||2===e.type}function oc(e){return 7===e.type&&"pre"===e.name}function ou(e){return 7===e.type&&"slot"===e.name}function od(e){return 1===e.type&&3===e.tagType}function oh(e){return 1===e.type&&2===e.tagType}let op=new Set([sk,sT]);function of(e,t,n){let r,i,l=13===e.type?e.props:e.arguments[2],s=[];if(l&&!R(l)&&14===l.type){let e=function e(t,n=[]){if(t&&!R(t)&&14===t.type){let r=t.callee;if(!R(r)&&op.has(r))return e(t.arguments[0],n.concat(t))}return[t,n]}(l);l=e[0],i=(s=e[1])[s.length-1]}if(null==l||R(l))r=sU([t]);else if(14===l.type){let e=l.arguments[0];R(e)||15!==e.type?l.callee===sw?r=sK(n.helper(sS),[sU([t]),l]):l.arguments.unshift(sU([t])):og(t,e)||e.properties.unshift(t),r||(r=l)}else 15===l.type?(og(t,l)||l.properties.unshift(t),r=l):(r=sK(n.helper(sS),[sU([t]),l]),i&&i.callee===sT&&(i=s[s.length-2]));13===e.type?i?i.arguments[0]=r:e.props=r:i?i.arguments[0]=r:e.arguments[2]=r}function og(e,t){let n=!1;if(4===e.key.type){let r=e.key.content;n=t.properties.some(e=>4===e.key.type&&e.key.content===r)}return n}function om(e,t){return`_${t}_${e.replace(/[^\w]/g,(t,n)=>"-"===t?"_":e.charCodeAt(n).toString())}`}let ov=/([\s\S]*?)\s+(?:in|of)\s+(\S[\s\S]*)/;function oy(e){for(let t=0;t<e.length;t++)if(!sY(e.charCodeAt(t)))return!1;return!0}function ob(e){return 2===e.type&&oy(e.content)||12===e.type&&ob(e.content)}function o_(e){return 3===e.type||ob(e)}let oS={parseMode:"base",ns:0,delimiters:["{{","}}"],getNamespace:()=>0,isVoidTag:x,isPreTag:x,isIgnoreNewlineTag:x,isCustomElement:x,onError:s6,onWarn:s3,comments:!1,prefixIdentifiers:!1},ox=oS,oC=null,ok="",oT=null,ow=null,oN="",oA=-1,oE=-1,oI=0,oR=!1,oO=null,oM=[],oP=new class{constructor(e,t){this.stack=e,this.cbs=t,this.state=1,this.buffer="",this.sectionStart=0,this.index=0,this.entityStart=0,this.baseState=1,this.inRCDATA=!1,this.inXML=!1,this.inVPre=!1,this.newlines=[],this.mode=0,this.delimiterOpen=sX,this.delimiterClose=sQ,this.delimiterIndex=-1,this.currentSequence=void 0,this.sequenceIndex=0}get inSFCRoot(){return 2===this.mode&&0===this.stack.length}reset(){this.state=1,this.mode=0,this.buffer="",this.sectionStart=0,this.index=0,this.baseState=1,this.inRCDATA=!1,this.currentSequence=void 0,this.newlines.length=0,this.delimiterOpen=sX,this.delimiterClose=sQ}getPos(e){let t=1,n=e+1,r=this.newlines.length,i=-1;if(r>100){let t=-1,n=r;for(;t+1<n;){let r=t+n>>>1;this.newlines[r]<e?t=r:n=r}i=t}else for(let t=r-1;t>=0;t--)if(e>this.newlines[t]){i=t;break}return i>=0&&(t=i+2,n=e-this.newlines[i]),{column:n,line:t,offset:e}}peek(){return this.buffer.charCodeAt(this.index+1)}stateText(e){60===e?(this.index>this.sectionStart&&this.cbs.ontext(this.sectionStart,this.index),this.state=5,this.sectionStart=this.index):this.inVPre||e!==this.delimiterOpen[0]||(this.state=2,this.delimiterIndex=0,this.stateInterpolationOpen(e))}stateInterpolationOpen(e){if(e===this.delimiterOpen[this.delimiterIndex])if(this.delimiterIndex===this.delimiterOpen.length-1){let e=this.index+1-this.delimiterOpen.length;e>this.sectionStart&&this.cbs.ontext(this.sectionStart,e),this.state=3,this.sectionStart=e}else this.delimiterIndex++;else this.inRCDATA?(this.state=32,this.stateInRCDATA(e)):(this.state=1,this.stateText(e))}stateInterpolation(e){e===this.delimiterClose[0]&&(this.state=4,this.delimiterIndex=0,this.stateInterpolationClose(e))}stateInterpolationClose(e){e===this.delimiterClose[this.delimiterIndex]?this.delimiterIndex===this.delimiterClose.length-1?(this.cbs.oninterpolation(this.sectionStart,this.index+1),this.inRCDATA?this.state=32:this.state=1,this.sectionStart=this.index+1):this.delimiterIndex++:(this.state=3,this.stateInterpolation(e))}stateSpecialStartSequence(e){let t=this.sequenceIndex===this.currentSequence.length;if(t?s0(e):(32|e)===this.currentSequence[this.sequenceIndex]){if(!t)return void this.sequenceIndex++}else this.inRCDATA=!1;this.sequenceIndex=0,this.state=6,this.stateInTagName(e)}stateInRCDATA(e){if(this.sequenceIndex===this.currentSequence.length){if(62===e||sY(e)){let t=this.index-this.currentSequence.length;if(this.sectionStart<t){let e=this.index;this.index=t,this.cbs.ontext(this.sectionStart,t),this.index=e}this.sectionStart=t+2,this.stateInClosingTagName(e),this.inRCDATA=!1;return}this.sequenceIndex=0}(32|e)===this.currentSequence[this.sequenceIndex]?this.sequenceIndex+=1:0===this.sequenceIndex?this.currentSequence!==s2.TitleEnd&&(this.currentSequence!==s2.TextareaEnd||this.inSFCRoot)?this.fastForwardTo(60)&&(this.sequenceIndex=1):this.inVPre||e!==this.delimiterOpen[0]||(this.state=2,this.delimiterIndex=0,this.stateInterpolationOpen(e)):this.sequenceIndex=Number(60===e)}stateCDATASequence(e){e===s2.Cdata[this.sequenceIndex]?++this.sequenceIndex===s2.Cdata.length&&(this.state=28,this.currentSequence=s2.CdataEnd,this.sequenceIndex=0,this.sectionStart=this.index+1):(this.sequenceIndex=0,this.state=23,this.stateInDeclaration(e))}fastForwardTo(e){for(;++this.index<this.buffer.length;){let t=this.buffer.charCodeAt(this.index);if(10===t&&this.newlines.push(this.index),t===e)return!0}return this.index=this.buffer.length-1,!1}stateInCommentLike(e){e===this.currentSequence[this.sequenceIndex]?++this.sequenceIndex===this.currentSequence.length&&(this.currentSequence===s2.CdataEnd?this.cbs.oncdata(this.sectionStart,this.index-2):this.cbs.oncomment(this.sectionStart,this.index-2),this.sequenceIndex=0,this.sectionStart=this.index+1,this.state=1):0===this.sequenceIndex?this.fastForwardTo(this.currentSequence[0])&&(this.sequenceIndex=1):e!==this.currentSequence[this.sequenceIndex-1]&&(this.sequenceIndex=0)}startSpecial(e,t){this.enterRCDATA(e,t),this.state=31}enterRCDATA(e,t){this.inRCDATA=!0,this.currentSequence=e,this.sequenceIndex=t}stateBeforeTagName(e){33===e?(this.state=22,this.sectionStart=this.index+1):63===e?(this.state=24,this.sectionStart=this.index+1):sZ(e)?(this.sectionStart=this.index,0===this.mode?this.state=6:this.inSFCRoot?this.state=34:this.inXML?this.state=6:116===e?this.state=30:this.state=115===e?29:6):47===e?this.state=8:(this.state=1,this.stateText(e))}stateInTagName(e){s0(e)&&this.handleTagName(e)}stateInSFCRootTagName(e){if(s0(e)){let t=this.buffer.slice(this.sectionStart,this.index);"template"!==t&&this.enterRCDATA(s1("</"+t),0),this.handleTagName(e)}}handleTagName(e){this.cbs.onopentagname(this.sectionStart,this.index),this.sectionStart=-1,this.state=11,this.stateBeforeAttrName(e)}stateBeforeClosingTagName(e){sY(e)||(62===e?(this.state=1,this.sectionStart=this.index+1):(this.state=sZ(e)?9:27,this.sectionStart=this.index))}stateInClosingTagName(e){(62===e||sY(e))&&(this.cbs.onclosetag(this.sectionStart,this.index),this.sectionStart=-1,this.state=10,this.stateAfterClosingTagName(e))}stateAfterClosingTagName(e){62===e&&(this.state=1,this.sectionStart=this.index+1)}stateBeforeAttrName(e){62===e?(this.cbs.onopentagend(this.index),this.inRCDATA?this.state=32:this.state=1,this.sectionStart=this.index+1):47===e?this.state=7:60===e&&47===this.peek()?(this.cbs.onopentagend(this.index),this.state=5,this.sectionStart=this.index):sY(e)||this.handleAttrStart(e)}handleAttrStart(e){118===e&&45===this.peek()?(this.state=13,this.sectionStart=this.index):46===e||58===e||64===e||35===e?(this.cbs.ondirname(this.index,this.index+1),this.state=14,this.sectionStart=this.index+1):(this.state=12,this.sectionStart=this.index)}stateInSelfClosingTag(e){62===e?(this.cbs.onselfclosingtag(this.index),this.state=1,this.sectionStart=this.index+1,this.inRCDATA=!1):sY(e)||(this.state=11,this.stateBeforeAttrName(e))}stateInAttrName(e){(61===e||s0(e))&&(this.cbs.onattribname(this.sectionStart,this.index),this.handleAttrNameEnd(e))}stateInDirName(e){61===e||s0(e)?(this.cbs.ondirname(this.sectionStart,this.index),this.handleAttrNameEnd(e)):58===e?(this.cbs.ondirname(this.sectionStart,this.index),this.state=14,this.sectionStart=this.index+1):46===e&&(this.cbs.ondirname(this.sectionStart,this.index),this.state=16,this.sectionStart=this.index+1)}stateInDirArg(e){61===e||s0(e)?(this.cbs.ondirarg(this.sectionStart,this.index),this.handleAttrNameEnd(e)):91===e?this.state=15:46===e&&(this.cbs.ondirarg(this.sectionStart,this.index),this.state=16,this.sectionStart=this.index+1)}stateInDynamicDirArg(e){93===e?this.state=14:(61===e||s0(e))&&(this.cbs.ondirarg(this.sectionStart,this.index+1),this.handleAttrNameEnd(e))}stateInDirModifier(e){61===e||s0(e)?(this.cbs.ondirmodifier(this.sectionStart,this.index),this.handleAttrNameEnd(e)):46===e&&(this.cbs.ondirmodifier(this.sectionStart,this.index),this.sectionStart=this.index+1)}handleAttrNameEnd(e){this.sectionStart=this.index,this.state=17,this.cbs.onattribnameend(this.index),this.stateAfterAttrName(e)}stateAfterAttrName(e){61===e?this.state=18:47===e||62===e?(this.cbs.onattribend(0,this.sectionStart),this.sectionStart=-1,this.state=11,this.stateBeforeAttrName(e)):sY(e)||(this.cbs.onattribend(0,this.sectionStart),this.handleAttrStart(e))}stateBeforeAttrValue(e){34===e?(this.state=19,this.sectionStart=this.index+1):39===e?(this.state=20,this.sectionStart=this.index+1):sY(e)||(this.sectionStart=this.index,this.state=21,this.stateInAttrValueNoQuotes(e))}handleInAttrValue(e,t){(e===t||this.fastForwardTo(t))&&(this.cbs.onattribdata(this.sectionStart,this.index),this.sectionStart=-1,this.cbs.onattribend(34===t?3:2,this.index+1),this.state=11)}stateInAttrValueDoubleQuotes(e){this.handleInAttrValue(e,34)}stateInAttrValueSingleQuotes(e){this.handleInAttrValue(e,39)}stateInAttrValueNoQuotes(e){sY(e)||62===e?(this.cbs.onattribdata(this.sectionStart,this.index),this.sectionStart=-1,this.cbs.onattribend(1,this.index),this.state=11,this.stateBeforeAttrName(e)):(39===e||60===e||61===e||96===e)&&this.cbs.onerr(18,this.index)}stateBeforeDeclaration(e){91===e?(this.state=26,this.sequenceIndex=0):this.state=45===e?25:23}stateInDeclaration(e){(62===e||this.fastForwardTo(62))&&(this.state=1,this.sectionStart=this.index+1)}stateInProcessingInstruction(e){(62===e||this.fastForwardTo(62))&&(this.cbs.onprocessinginstruction(this.sectionStart,this.index),this.state=1,this.sectionStart=this.index+1)}stateBeforeComment(e){45===e?(this.state=28,this.currentSequence=s2.CommentEnd,this.sequenceIndex=2,this.sectionStart=this.index+1):this.state=23}stateInSpecialComment(e){(62===e||this.fastForwardTo(62))&&(this.cbs.oncomment(this.sectionStart,this.index),this.state=1,this.sectionStart=this.index+1)}stateBeforeSpecialS(e){e===s2.ScriptEnd[3]?this.startSpecial(s2.ScriptEnd,4):e===s2.StyleEnd[3]?this.startSpecial(s2.StyleEnd,4):(this.state=6,this.stateInTagName(e))}stateBeforeSpecialT(e){e===s2.TitleEnd[3]?this.startSpecial(s2.TitleEnd,4):e===s2.TextareaEnd[3]?this.startSpecial(s2.TextareaEnd,4):(this.state=6,this.stateInTagName(e))}startEntity(){}stateInEntity(){}parse(e){for(this.buffer=e;this.index<this.buffer.length;){let e=this.buffer.charCodeAt(this.index);switch(10===e&&33!==this.state&&this.newlines.push(this.index),this.state){case 1:this.stateText(e);break;case 2:this.stateInterpolationOpen(e);break;case 3:this.stateInterpolation(e);break;case 4:this.stateInterpolationClose(e);break;case 31:this.stateSpecialStartSequence(e);break;case 32:this.stateInRCDATA(e);break;case 26:this.stateCDATASequence(e);break;case 19:this.stateInAttrValueDoubleQuotes(e);break;case 12:this.stateInAttrName(e);break;case 13:this.stateInDirName(e);break;case 14:this.stateInDirArg(e);break;case 15:this.stateInDynamicDirArg(e);break;case 16:this.stateInDirModifier(e);break;case 28:this.stateInCommentLike(e);break;case 27:this.stateInSpecialComment(e);break;case 11:this.stateBeforeAttrName(e);break;case 6:this.stateInTagName(e);break;case 34:this.stateInSFCRootTagName(e);break;case 9:this.stateInClosingTagName(e);break;case 5:this.stateBeforeTagName(e);break;case 17:this.stateAfterAttrName(e);break;case 20:this.stateInAttrValueSingleQuotes(e);break;case 18:this.stateBeforeAttrValue(e);break;case 8:this.stateBeforeClosingTagName(e);break;case 10:this.stateAfterClosingTagName(e);break;case 29:this.stateBeforeSpecialS(e);break;case 30:this.stateBeforeSpecialT(e);break;case 21:this.stateInAttrValueNoQuotes(e);break;case 7:this.stateInSelfClosingTag(e);break;case 23:this.stateInDeclaration(e);break;case 22:this.stateBeforeDeclaration(e);break;case 25:this.stateBeforeComment(e);break;case 24:this.stateInProcessingInstruction(e);break;case 33:this.stateInEntity()}this.index++}this.cleanup(),this.finish()}cleanup(){this.sectionStart!==this.index&&(1===this.state||32===this.state&&0===this.sequenceIndex?(this.cbs.ontext(this.sectionStart,this.index),this.sectionStart=this.index):(19===this.state||20===this.state||21===this.state)&&(this.cbs.onattribdata(this.sectionStart,this.index),this.sectionStart=this.index))}finish(){this.handleTrailingData(),this.cbs.onend()}handleTrailingData(){let e=this.buffer.length;this.sectionStart>=e||(28===this.state?this.currentSequence===s2.CdataEnd?this.cbs.oncdata(this.sectionStart,e):this.cbs.oncomment(this.sectionStart,e):6===this.state||11===this.state||18===this.state||17===this.state||12===this.state||13===this.state||14===this.state||15===this.state||16===this.state||20===this.state||19===this.state||21===this.state||9===this.state||this.cbs.ontext(this.sectionStart,e))}emitCodePoint(e,t){}}(oM,{onerr:oX,ontext(e,t){oV(o$(e,t),e,t)},ontextentity(e,t,n){oV(e,t,n)},oninterpolation(e,t){if(oR)return oV(o$(e,t),e,t);let n=e+oP.delimiterOpen.length,r=t-oP.delimiterClose.length;for(;sY(ok.charCodeAt(n));)n++;for(;sY(ok.charCodeAt(r-1));)r--;let i=o$(n,r);i.includes("&")&&(i=ox.decodeEntities(i,!1)),oK({type:5,content:oG(i,!1,oz(n,r)),loc:oz(e,t)})},onopentagname(e,t){let n=o$(e,t);oT={type:1,tag:n,ns:ox.getNamespace(n,oM[0],ox.ns),tagType:0,props:[],children:[],loc:oz(e-1,t),codegenNode:void 0}},onopentagend(e){oD(e)},onclosetag(e,t){let n=o$(e,t);if(!ox.isVoidTag(n)){let r=!1;for(let e=0;e<oM.length;e++)if(oM[e].tag.toLowerCase()===n.toLowerCase()){r=!0,e>0&&oM[0].loc.start.offset;for(let n=0;n<=e;n++)oB(oM.shift(),t,n<e);break}r||oj(e,60)}},onselfclosingtag(e){let t=oT.tag;oT.isSelfClosing=!0,oD(e),oM[0]&&oM[0].tag===t&&oB(oM.shift(),e)},onattribname(e,t){ow={type:6,name:o$(e,t),nameLoc:oz(e,t),value:void 0,loc:oz(e)}},ondirname(e,t){let n=o$(e,t),r="."===n||":"===n?"bind":"@"===n?"on":"#"===n?"slot":n.slice(2);if(oR||""===r)ow={type:6,name:n,nameLoc:oz(e,t),value:void 0,loc:oz(e)};else if(ow={type:7,name:r,rawName:n,exp:void 0,arg:void 0,modifiers:"."===n?[sq("prop")]:[],loc:oz(e)},"pre"===r){oR=oP.inVPre=!0,oO=oT;let e=oT.props;for(let t=0;t<e.length;t++)7===e[t].type&&(e[t]=function(e){let t={type:6,name:e.rawName,nameLoc:oz(e.loc.start.offset,e.loc.start.offset+e.rawName.length),value:void 0,loc:e.loc};if(e.exp){let n=e.exp.loc;n.end.offset<e.loc.end.offset&&(n.start.offset--,n.start.column--,n.end.offset++,n.end.column++),t.value={type:2,content:e.exp.content,loc:n}}return t}(e[t]))}},ondirarg(e,t){if(e===t)return;let n=o$(e,t);if(oR&&!oc(ow))ow.name+=n,oJ(ow.nameLoc,t);else{let r="["!==n[0];ow.arg=oG(r?n:n.slice(1,-1),r,oz(e,t),3*!!r)}},ondirmodifier(e,t){let n=o$(e,t);if(oR&&!oc(ow))ow.name+="."+n,oJ(ow.nameLoc,t);else if("slot"===ow.name){let e=ow.arg;e&&(e.content+="."+n,oJ(e.loc,t))}else{let r=sq(n,!0,oz(e,t));ow.modifiers.push(r)}},onattribdata(e,t){oN+=o$(e,t),oA<0&&(oA=e),oE=t},onattribentity(e,t,n){oN+=e,oA<0&&(oA=t),oE=n},onattribnameend(e){let t=o$(ow.loc.start.offset,e);7===ow.type&&(ow.rawName=t),oT.props.some(e=>(7===e.type?e.rawName:e.name)===t)},onattribend(e,t){oT&&ow&&(oJ(ow.loc,t),0!==e&&(oN.includes("&")&&(oN=ox.decodeEntities(oN,!0)),6===ow.type?("class"===ow.name&&(oN=oW(oN).trim()),ow.value={type:2,content:oN,loc:1===e?oz(oA,oE):oz(oA-1,oE+1)},oP.inSFCRoot&&"template"===oT.tag&&"lang"===ow.name&&oN&&"html"!==oN&&oP.enterRCDATA(s1("</template"),0)):(ow.exp=oG(oN,!1,oz(oA,oE),0,0),"for"===ow.name&&(ow.forParseResult=function(e){let t=e.loc,n=e.content,r=n.match(ov);if(!r)return;let[,i,l]=r,s=(e,n,r=!1)=>{let i=t.start.offset+n,l=i+e.length;return oG(e,!1,oz(i,l),0,+!!r)},o={source:s(l.trim(),n.indexOf(l,i.length)),value:void 0,key:void 0,index:void 0,finalized:!1},a=i.trim().replace(oL,"").trim(),c=i.indexOf(a),u=a.match(oF);if(u){let e;a=a.replace(oF,"").trim();let t=u[1].trim();if(t&&(e=n.indexOf(t,c+a.length),o.key=s(t,e,!0)),u[2]){let r=u[2].trim();r&&(o.index=s(r,n.indexOf(r,o.key?e+t.length:c+a.length),!0))}}return a&&(o.value=s(a,c,!0)),o}(ow.exp)))),(7!==ow.type||"pre"!==ow.name)&&oT.props.push(ow)),oN="",oA=oE=-1},oncomment(e,t){ox.comments&&oK({type:3,content:o$(e,t),loc:oz(e-4,t+3)})},onend(){let e=ok.length;for(let t=0;t<oM.length;t++)oB(oM[t],e-1),oM[t].loc.start.offset},oncdata(e,t){(oM[0]?oM[0].ns:ox.ns)!==0&&oV(o$(e,t),e,t)},onprocessinginstruction(e){(oM[0]?oM[0].ns:ox.ns)===0&&oX(21,e-1)}}),oF=/,([^,\}\]]*)(?:,([^,\}\]]*))?$/,oL=/^\(|\)$/g;function o$(e,t){return ok.slice(e,t)}function oD(e){oP.inSFCRoot&&(oT.innerLoc=oz(e+1,e+1)),oK(oT);let{tag:t,ns:n}=oT;0===n&&ox.isPreTag(t)&&oI++,ox.isVoidTag(t)?oB(oT,e):(oM.unshift(oT),(1===n||2===n)&&(oP.inXML=!0)),oT=null}function oV(e,t,n){{let t=oM[0]&&oM[0].tag;"script"!==t&&"style"!==t&&e.includes("&")&&(e=ox.decodeEntities(e,!1))}let r=oM[0]||oC,i=r.children[r.children.length-1];i&&2===i.type?(i.content+=e,oJ(i.loc,n)):r.children.push({type:2,content:e,loc:oz(t,n)})}function oB(e,t,n=!1){n?oJ(e.loc,oj(t,60)):oJ(e.loc,function(e){let t=e;for(;62!==ok.charCodeAt(t)&&t<ok.length-1;)t++;return t}(t)+1),oP.inSFCRoot&&(e.children.length?e.innerLoc.end=T({},e.children[e.children.length-1].loc.end):e.innerLoc.end=T({},e.innerLoc.start),e.innerLoc.source=o$(e.innerLoc.start.offset,e.innerLoc.end.offset));let{tag:r,ns:i,children:l}=e;if(!oR&&("slot"===r?e.tagType=2:!function({tag:e,props:t}){if("template"===e){for(let e=0;e<t.length;e++)if(7===t[e].type&&oU.has(t[e].name))return!0}return!1}(e)?function({tag:e,props:t}){var n;if(ox.isCustomElement(e))return!1;if("component"===e||(n=e.charCodeAt(0))>64&&n<91||s5(e)||ox.isBuiltInComponent&&ox.isBuiltInComponent(e)||ox.isNativeTag&&!ox.isNativeTag(e))return!0;for(let e=0;e<t.length;e++){let n=t[e];if(6===n.type&&"is"===n.name&&n.value&&n.value.content.startsWith("vue:"))return!0}return!1}(e)&&(e.tagType=1):e.tagType=3),oP.inRCDATA||(e.children=oq(l)),0===i&&ox.isIgnoreNewlineTag(r)){let e=l[0];e&&2===e.type&&(e.content=e.content.replace(/^\r?\n/,""))}0===i&&ox.isPreTag(r)&&oI--,oO===e&&(oR=oP.inVPre=!1,oO=null),oP.inXML&&(oM[0]?oM[0].ns:ox.ns)===0&&(oP.inXML=!1)}function oj(e,t){let n=e;for(;ok.charCodeAt(n)!==t&&n>=0;)n--;return n}let oU=new Set(["if","else","else-if","for","slot"]),oH=/\r\n/g;function oq(e){let t="preserve"!==ox.whitespace,n=!1;for(let r=0;r<e.length;r++){let i=e[r];if(2===i.type)if(oI)i.content=i.content.replace(oH,`
+`);else if(oy(i.content)){let l=e[r-1]&&e[r-1].type,s=e[r+1]&&e[r+1].type;!l||!s||t&&(3===l&&(3===s||1===s)||1===l&&(3===s||1===s&&function(e){for(let t=0;t<e.length;t++){let n=e.charCodeAt(t);if(10===n||13===n)return!0}return!1}(i.content)))?(n=!0,e[r]=null):i.content=" "}else t&&(i.content=oW(i.content))}return n?e.filter(Boolean):e}function oW(e){let t="",n=!1;for(let r=0;r<e.length;r++)sY(e.charCodeAt(r))?n||(t+=" ",n=!0):(t+=e[r],n=!1);return t}function oK(e){(oM[0]||oC).children.push(e)}function oz(e,t){return{start:oP.getPos(e),end:null==t?t:oP.getPos(t),source:null==t?t:o$(e,t)}}function oJ(e,t){e.end=oP.getPos(t),e.source=o$(e.start.offset,t)}function oG(e,t=!1,n,r=0,i=0){return sq(e,t,n,r)}function oX(e,t,n){ox.onError(s4(e,oz(t,t)))}function oQ(e){let t=e.children.filter(e=>3!==e.type);return 1!==t.length||1!==t[0].type||oh(t[0])?null:t[0]}function oZ(e,t){let{constantCache:n}=t;switch(e.type){case 1:if(0!==e.tagType)return 0;let r=n.get(e);if(void 0!==r)return r;let i=e.codegenNode;if(13!==i.type||i.isBlock&&"svg"!==e.tag&&"foreignObject"!==e.tag&&"math"!==e.tag)return 0;if(void 0!==i.patchFlag)return n.set(e,0),0;{let r=3,c=o0(e,t);if(0===c)return n.set(e,0),0;c<r&&(r=c);for(let i=0;i<e.children.length;i++){let l=oZ(e.children[i],t);if(0===l)return n.set(e,0),0;l<r&&(r=l)}if(r>1)for(let i=0;i<e.props.length;i++){let l=e.props[i];if(7===l.type&&"bind"===l.name&&l.exp){let i=oZ(l.exp,t);if(0===i)return n.set(e,0),0;i<r&&(r=i)}}if(i.isBlock){var l,s,o,a;for(let t=0;t<e.props.length;t++)if(7===e.props[t].type)return n.set(e,0),0;t.removeHelper(si),t.removeHelper((l=t.inSSR,s=i.isComponent,l||s?sl:ss)),i.isBlock=!1,t.helper((o=t.inSSR,a=i.isComponent,o||a?so:sa))}return n.set(e,r),r}case 2:case 3:return 3;case 9:case 11:case 10:default:return 0;case 5:case 12:return oZ(e.content,t);case 4:return e.constType;case 8:let c=3;for(let n=0;n<e.children.length;n++){let r=e.children[n];if(R(r)||O(r))continue;let i=oZ(r,t);if(0===i)return 0;i<c&&(c=i)}return c;case 20:return 2}}let oY=new Set([sx,sC,sk,sT]);function o0(e,t){let n=3,r=o1(e);if(r&&15===r.type){let{properties:e}=r;for(let r=0;r<e.length;r++){let i,{key:l,value:s}=e[r],o=oZ(l,t);if(0===o)return o;if(o<n&&(n=o),0===(i=4===s.type?oZ(s,t):14===s.type?function e(t,n){if(14===t.type&&!R(t.callee)&&oY.has(t.callee)){let r=t.arguments[0];if(4===r.type)return oZ(r,n);if(14===r.type)return e(r,n)}return 0}(s,t):0))return i;i<n&&(n=i)}}return n}function o1(e){let t=e.codegenNode;if(13===t.type)return t.props}function o2(e,t){t.currentNode=e;let{nodeTransforms:n}=t,r=[];for(let i=0;i<n.length;i++){let l=n[i](e,t);if(l&&(E(l)?r.push(...l):r.push(l)),!t.currentNode)return;e=t.currentNode}switch(e.type){case 3:t.ssr||t.helper(sc);break;case 5:t.ssr||t.helper(s_);break;case 9:for(let n=0;n<e.branches.length;n++)o2(e.branches[n],t);break;case 10:case 11:case 1:case 0:var i=e;let l=0,s=()=>{l--};for(;l<i.children.length;l++){let e=i.children[l];R(e)||(t.grandParent=t.parent,t.parent=i,t.childIndex=l,t.onNodeRemoved=s,o2(e,t))}}t.currentNode=e;let o=r.length;for(;o--;)r[o]()}function o6(e,t){let n=R(e)?t=>t===e:t=>e.test(t);return(e,r)=>{if(1===e.type){let{props:i}=e;if(3===e.tagType&&i.some(ou))return;let l=[];for(let s=0;s<i.length;s++){let o=i[s];if(7===o.type&&n(o.name)){i.splice(s,1),s--;let n=t(e,o,r);n&&l.push(n)}}return l}}}let o3="/*@__PURE__*/",o4=e=>`${sD[e]}: _${sD[e]}`;function o8(e,t,{helper:n,push:r,newline:i,isTS:l}){let s=n("component"===t?sh:sf);for(let n=0;n<e.length;n++){let o=e[n],a=o.endsWith("__self");a&&(o=o.slice(0,-6)),r(`const ${om(o,t)} = ${s}(${JSON.stringify(o)}${a?", true":""})${l?"!":""}`),n<e.length-1&&i()}}function o5(e,t){let n=e.length>3;t.push("["),n&&t.indent(),o9(e,t,n),n&&t.deindent(),t.push("]")}function o9(e,t,n=!1,r=!0){let{push:i,newline:l}=t;for(let s=0;s<e.length;s++){let o=e[s];R(o)?i(o,-3):E(o)?o5(o,t):o7(o,t),s<e.length-1&&(n?(r&&i(","),l()):r&&i(", "))}}function o7(e,t){var n,r,i;if(R(e))return void t.push(e,-3);if(O(e))return void t.push(t.helper(e));switch(e.type){case 1:case 9:case 11:case 12:o7(e.codegenNode,t);break;case 2:n=e,t.push(JSON.stringify(n.content),-3,n);break;case 4:ae(e,t);break;case 5:!function(e,t){let{push:n,helper:r,pure:i}=t;i&&n(o3),n(`${r(s_)}(`),o7(e.content,t),n(")")}(e,t);break;case 8:at(e,t);break;case 3:!function(e,t){let{push:n,helper:r,pure:i}=t;i&&n(o3),n(`${r(sc)}(${JSON.stringify(e.content)})`,-3,e)}(e,t);break;case 13:!function(e,t){var n,r;let i,{push:l,helper:s,pure:o}=t,{tag:a,props:c,children:u,patchFlag:d,dynamicProps:h,directives:p,isBlock:f,disableTracking:g,isComponent:m}=e;d&&(i=String(d)),p&&l(s(sm)+"("),f&&l(`(${s(si)}(${g?"true":""}), `),o&&l(o3),l(s(f?(n=t.inSSR,n||m?sl:ss):(r=t.inSSR,r||m?so:sa))+"(",-2,e),o9(function(e){let t=e.length;for(;t--&&null==e[t];);return e.slice(0,t+1).map(e=>e||"null")}([a,c,u,i,h]),t),l(")"),f&&l(")"),p&&(l(", "),o7(p,t),l(")"))}(e,t);break;case 14:!function(e,t){let{push:n,helper:r,pure:i}=t,l=R(e.callee)?e.callee:r(e.callee);i&&n(o3),n(l+"(",-2,e),o9(e.arguments,t),n(")")}(e,t);break;case 15:!function(e,t){let{push:n,indent:r,deindent:i,newline:l}=t,{properties:s}=e;if(!s.length)return n("{}",-2,e);let o=s.length>1;n(o?"{":"{ "),o&&r();for(let e=0;e<s.length;e++){let{key:r,value:i}=s[e];!function(e,t){let{push:n}=t;if(8===e.type)n("["),at(e,t),n("]");else if(e.isStatic){let t;n((t=e.content,s9.test(t))?JSON.stringify(e.content):e.content,-2,e)}else n(`[${e.content}]`,-3,e)}(r,t),n(": "),o7(i,t),e<s.length-1&&(n(","),l())}o&&i(),n(o?"}":" }")}(e,t);break;case 17:r=e,i=t,o5(r.elements,i);break;case 18:!function(e,t){let{push:n,indent:r,deindent:i}=t,{params:l,returns:s,body:o,newline:a,isSlot:c}=e;c&&n(`_${sD[sM]}(`),n("(",-2,e),E(l)?o9(l,t):l&&o7(l,t),n(") => "),(a||o)&&(n("{"),r()),s?(a&&n("return "),E(s)?o5(s,t):o7(s,t)):o&&o7(o,t),(a||o)&&(i(),n("}")),c&&n(")")}(e,t);break;case 19:!function(e,t){let{test:n,consequent:r,alternate:i,newline:l}=e,{push:s,indent:o,deindent:a,newline:c}=t;if(4===n.type){let e,r=(e=n.content,!!s9.test(e));r&&s("("),ae(n,t),r&&s(")")}else s("("),o7(n,t),s(")");l&&o(),t.indentLevel++,l||s(" "),s("? "),o7(r,t),t.indentLevel--,l&&c(),l||s(" "),s(": ");let u=19===i.type;!u&&t.indentLevel++,o7(i,t),!u&&t.indentLevel--,l&&a(!0)}(e,t);break;case 20:!function(e,t){let{push:n,helper:r,indent:i,deindent:l,newline:s}=t,{needPauseTracking:o,needArraySpread:a}=e;a&&n("[...("),n(`_cache[${e.index}] || (`),o&&(i(),n(`${r(sI)}(-1`),e.inVOnce&&n(", true"),n("),"),s(),n("(")),n(`_cache[${e.index}] = `),o7(e.value,t),o&&(n(`).cacheIndex = ${e.index},`),s(),n(`${r(sI)}(1),`),s(),n(`_cache[${e.index}]`),l()),n(")"),a&&n(")]")}(e,t);break;case 21:o9(e.body,t,!0,!1)}}function ae(e,t){let{content:n,isStatic:r}=e;t.push(r?JSON.stringify(n):n,-3,e)}function at(e,t){for(let n=0;n<e.children.length;n++){let r=e.children[n];R(r)?t.push(r,-3):o7(r,t)}}let an=o6(/^(?:if|else|else-if)$/,(e,t,n)=>(function(e,t,n,r){if("else"!==t.name&&(!t.exp||!t.exp.content.trim())){let r=t.exp?t.exp.loc:e.loc;n.onError(s4(28,t.loc)),t.exp=sq("true",!1,r)}if("if"===t.name){var i;let l=ar(e,t),s={type:9,loc:oz((i=e.loc).start.offset,i.end.offset),branches:[l]};if(n.replaceNode(s),r)return r(s,l,!0)}else{let i=n.parent.children,l=i.indexOf(e);for(;l-- >=-1;){let s=i[l];if(s&&o_(s)){n.removeNode(s);continue}if(s&&9===s.type){("else-if"===t.name||"else"===t.name)&&void 0===s.branches[s.branches.length-1].condition&&n.onError(s4(30,e.loc)),n.removeNode();let i=ar(e,t);s.branches.push(i);let l=r&&r(s,i,!1);o2(i,n),l&&l(),n.currentNode=null}else n.onError(s4(30,e.loc));break}}})(e,t,n,(e,t,r)=>{let i=n.parent.children,l=i.indexOf(e),s=0;for(;l-- >=0;){let e=i[l];e&&9===e.type&&(s+=e.branches.length)}return()=>{r?e.codegenNode=ai(t,s,n):function(e){for(;;)if(19===e.type)if(19!==e.alternate.type)return e;else e=e.alternate;else 20===e.type&&(e=e.value)}(e.codegenNode).alternate=ai(t,s+e.branches.length-1,n)}}));function ar(e,t){let n=3===e.tagType;return{type:10,loc:e.loc,condition:"else"===t.name?void 0:t.exp,children:n&&!ol(e,"for")?e.children:[e],userKey:os(e,"key"),isTemplateIf:n}}function ai(e,t,n){return e.condition?sJ(e.condition,al(e,t,n),sK(n.helper(sc),['""',"true"])):al(e,t,n)}function al(e,t,n){let{helper:r}=n,i=sH("key",sq(`${t}`,!1,sV,2)),{children:l}=e,s=l[0];if(1!==l.length||1!==s.type)if(1!==l.length||11!==s.type)return sB(n,r(l7),sU([i]),l,64,void 0,void 0,!0,!1,!1,e.loc);else{let e=s.codegenNode;return of(e,i,n),e}{let e=s.codegenNode,t=14===e.type&&e.callee===sL?e.arguments[1].returns:e;return 13===t.type&&sG(t,n),of(t,i,n),e}}let as=o6("for",(e,t,n)=>{let{helper:r,removeHelper:i}=n;return function(e,t,n,r){if(!t.exp)return void n.onError(s4(31,t.loc));let i=t.forParseResult;if(!i)return void n.onError(s4(32,t.loc));ao(i);let{scopes:l}=n,{source:s,value:o,key:a,index:c}=i,u={type:11,loc:t.loc,source:s,valueAlias:o,keyAlias:a,objectIndexAlias:c,parseResult:i,children:od(e)?e.children:[e]};n.replaceNode(u),l.vFor++;let d=r&&r(u);return()=>{l.vFor--,d&&d()}}(e,t,n,t=>{let l=sK(r(sv),[t.source]),s=od(e),o=ol(e,"memo"),a=os(e,"key",!1,!0);a&&a.type;let c=a&&(6===a.type?a.value?sq(a.value.content,!0):void 0:a.exp),u=c?sH("key",c):null,d=4===t.source.type&&t.source.constType>0,h=d?64:a?128:256;return t.codegenNode=sB(n,r(l7),void 0,l,h,void 0,void 0,!0,!d,!1,e.loc),()=>{let a,{children:h}=t,p=1!==h.length||1!==h[0].type,f=oh(e)?e:s&&1===e.children.length&&oh(e.children[0])?e.children[0]:null;if(f)a=f.codegenNode,s&&u&&of(a,u,n);else if(p)a=sB(n,r(l7),u?sU([u]):void 0,e.children,64,void 0,void 0,!0,void 0,!1);else{var g,m,y,b,_,S,x,C;a=h[0].codegenNode,s&&u&&of(a,u,n),!d!==a.isBlock&&(a.isBlock?(i(si),i((g=n.inSSR,m=a.isComponent,g||m?sl:ss))):i((y=n.inSSR,b=a.isComponent,y||b?so:sa))),(a.isBlock=!d,a.isBlock)?(r(si),r((_=n.inSSR,S=a.isComponent,_||S?sl:ss))):r((x=n.inSSR,C=a.isComponent,x||C?so:sa))}if(o){let e=sz(aa(t.parseResult,[sq("_cached")]));e.body={type:21,body:[sW(["const _memo = (",o.exp,")"]),sW(["if (_cached && _cached.el",...c?[" && _cached.key === ",c]:[],` && ${n.helperString(s$)}(_cached, _memo)) return _cached`]),sW(["const _item = ",a]),sq("_item.memo = _memo"),sq("return _item")],loc:sV},l.arguments.push(e,sq("_cache"),sq(String(n.cached.length))),n.cached.push(null)}else l.arguments.push(sz(aa(t.parseResult),a,!0))}})});function ao(e,t){e.finalized||(e.finalized=!0)}function aa({value:e,key:t,index:n},r=[]){var i=[e,t,n,...r];let l=i.length;for(;l--&&!i[l];);return i.slice(0,l+1).map((e,t)=>e||sq("_".repeat(t+1),!1))}let ac=sq("undefined",!1),au=(e,t)=>{if(1===e.type&&(1===e.tagType||3===e.tagType)){let n=ol(e,"slot");if(n)return n.exp,t.scopes.vSlot++,()=>{t.scopes.vSlot--}}};function ad(e,t,n){let r=[sH("name",e),sH("fn",t)];return null!=n&&r.push(sH("key",sq(String(n),!0))),sU(r)}let ah=new WeakMap,ap=(e,t)=>function(){let n,r,i,l,s;if(1!==(e=t.currentNode).type||0!==e.tagType&&1!==e.tagType)return;let{tag:o,props:a}=e,c=1===e.tagType,u=c?function(e,t,n=!1){let{tag:r}=e,i=am(r),l=os(e,"is",!1,!0);if(l)if(i){let e;if(6===l.type?e=l.value&&sq(l.value.content,!0):(e=l.exp)||(e=sq("is",!1,l.arg.loc)),e)return sK(t.helper(sp),[e])}else 6===l.type&&l.value.content.startsWith("vue:")&&(r=l.value.content.slice(4));let s=s5(r)||t.isBuiltInComponent(r);return s?(n||t.helper(s),s):(t.helper(sh),t.components.add(r),om(r,"component"))}(e,t):`"${o}"`,d=M(u)&&u.callee===sp,h=0,p=d||u===se||u===st||!c&&("svg"===o||"foreignObject"===o||"math"===o);if(a.length>0){let r=af(e,t,void 0,c,d);n=r.props,h=r.patchFlag,l=r.dynamicPropNames;let i=r.directives;s=i&&i.length?sj(i.map(e=>(function(e,t){let n=[],r=ah.get(e);r?n.push(t.helperString(r)):(t.helper(sf),t.directives.add(e.name),n.push(om(e.name,"directive")));let{loc:i}=e;if(e.exp&&n.push(e.exp),e.arg&&(e.exp||n.push("void 0"),n.push(e.arg)),Object.keys(e.modifiers).length){e.arg||(e.exp||n.push("void 0"),n.push("void 0"));let t=sq("true",!1,i);n.push(sU(e.modifiers.map(e=>sH(e,t)),i))}return sj(n,e.loc)})(e,t))):void 0,r.shouldUseBlock&&(p=!0)}if(e.children.length>0)if(u===sn&&(p=!0,h|=1024),c&&u!==se&&u!==sn){let{slots:n,hasDynamicSlots:i}=function(e,t,n=(e,t,n,r)=>sz(e,n,!1,!0,n.length?n[0].loc:r)){t.helper(sM);let{children:r,loc:i}=e,l=[],s=[],o=t.scopes.vSlot>0||t.scopes.vFor>0,a=ol(e,"slot",!0);if(a){let{arg:e,exp:t}=a;e&&!s8(e)&&(o=!0),l.push(sH(e||sq("default",!0),n(t,void 0,r,i)))}let c=!1,u=!1,d=[],h=new Set,p=0;for(let e=0;e<r.length;e++){let i,f,g,m,y=r[e];if(!od(y)||!(i=ol(y,"slot",!0))){3!==y.type&&d.push(y);continue}if(a){t.onError(s4(37,i.loc));break}c=!0;let{children:b,loc:_}=y,{arg:S=sq("default",!0),exp:x,loc:C}=i;s8(S)?f=S?S.content:"default":o=!0;let k=ol(y,"for"),T=n(x,k,b,_);if(g=ol(y,"if"))o=!0,s.push(sJ(g.exp,ad(S,T,p++),ac));else if(m=ol(y,/^else(?:-if)?$/,!0)){let n,i=e;for(;i--&&o_(n=r[i]););if(n&&od(n)&&ol(n,/^(?:else-)?if$/)){let e=s[s.length-1];for(;19===e.alternate.type;)e=e.alternate;e.alternate=m.exp?sJ(m.exp,ad(S,T,p++),ac):ad(S,T,p++)}else t.onError(s4(30,m.loc))}else if(k){o=!0;let e=k.forParseResult;e?(ao(e),s.push(sK(t.helper(sv),[e.source,sz(aa(e),ad(S,T),!0)]))):t.onError(s4(32,k.loc))}else{if(f){if(h.has(f)){t.onError(s4(38,C));continue}h.add(f),"default"===f&&(u=!0)}l.push(sH(S,T))}}if(!a){let e=(e,t)=>sH("default",n(e,void 0,t,i));c?d.length&&!d.every(ob)&&(u?t.onError(s4(39,d[0].loc)):l.push(e(void 0,d))):l.push(e(void 0,r))}let f=o?2:!function e(t){for(let n=0;n<t.length;n++){let r=t[n];switch(r.type){case 1:if(2===r.tagType||e(r.children))return!0;break;case 9:if(e(r.branches))return!0;break;case 10:case 11:if(e(r.children))return!0}}return!1}(e.children)?1:3,g=sU(l.concat(sH("_",sq(f+"",!1))),i);return s.length&&(g=sK(t.helper(sb),[g,sj(s)])),{slots:g,hasDynamicSlots:o}}(e,t);r=n,i&&(h|=1024)}else if(1===e.children.length&&u!==se){let n=e.children[0],i=n.type,l=5===i||8===i;l&&0===oZ(n,t)&&(h|=1),r=l||2===i?n:e.children}else r=e.children;l&&l.length&&(i=function(e){let t="[";for(let n=0,r=e.length;n<r;n++)t+=JSON.stringify(e[n]),n<r-1&&(t+=", ");return t+"]"}(l)),e.codegenNode=sB(t,u,n,r,0===h?void 0:h,i,s,!!p,!1,c,e.loc)};function af(e,t,n=e.props,r,i,l=!1){let s,{tag:o,loc:a,children:c}=e,u=[],d=[],h=[],p=c.length>0,f=!1,g=0,m=!1,y=!1,b=!1,_=!1,S=!1,x=!1,k=[],T=e=>{u.length&&(d.push(sU(ag(u),a)),u=[]),e&&d.push(e)},w=()=>{t.scopes.vFor>0&&u.push(sH(sq("ref_for",!0),sq("true")))},N=({key:e,value:n})=>{if(s8(e)){let l=e.content,s=C(l);s&&(!r||i)&&"onclick"!==l.toLowerCase()&&"onUpdate:modelValue"!==l&&!$(l)&&(_=!0),s&&$(l)&&(x=!0),s&&14===n.type&&(n=n.arguments[0]),20===n.type||(4===n.type||8===n.type)&&oZ(n,t)>0||("ref"===l?m=!0:"class"===l?y=!0:"style"===l?b=!0:"key"===l||k.includes(l)||k.push(l),r&&("class"===l||"style"===l)&&!k.includes(l)&&k.push(l))}else S=!0};for(let i=0;i<n.length;i++){let s=n[i];if(6===s.type){let{loc:e,name:t,nameLoc:n,value:r}=s;if("ref"===t&&(m=!0,w()),"is"===t&&(am(o)||r&&r.content.startsWith("vue:")))continue;u.push(sH(sq(t,!0,n),sq(r?r.content:"",!0,r?r.loc:e)))}else{let{name:n,arg:i,exp:c,loc:m,modifiers:y}=s,b="bind"===n,_="on"===n;if("slot"===n){r||t.onError(s4(40,m));continue}if("once"===n||"memo"===n||"is"===n||b&&oo(i,"is")&&am(o)||_&&l)continue;if((b&&oo(i,"key")||_&&p&&oo(i,"vue:before-update"))&&(f=!0),b&&oo(i,"ref")&&w(),!i&&(b||_)){S=!0,c?b?(w(),T(),d.push(c)):T({type:14,loc:m,callee:t.helper(sw),arguments:r?[c]:[c,"true"]}):t.onError(s4(b?34:35,m));continue}b&&y.some(e=>"prop"===e.content)&&(g|=32);let x=t.directiveTransforms[n];if(x){let{props:n,needRuntime:r}=x(s,e,t);l||n.forEach(N),_&&i&&!s8(i)?T(sU(n,a)):u.push(...n),r&&(h.push(s),O(r)&&ah.set(s,r))}else!D(n)&&(h.push(s),p&&(f=!0))}}if(d.length?(T(),s=d.length>1?sK(t.helper(sS),d,a):d[0]):u.length&&(s=sU(ag(u),a)),S?g|=16:(y&&!r&&(g|=2),b&&!r&&(g|=4),k.length&&(g|=8),_&&(g|=32)),!f&&(0===g||32===g)&&(m||x||h.length>0)&&(g|=512),!t.inSSR&&s)switch(s.type){case 15:let A=-1,E=-1,I=!1;for(let e=0;e<s.properties.length;e++){let t=s.properties[e].key;s8(t)?"class"===t.content?A=e:"style"===t.content&&(E=e):t.isHandlerKey||(I=!0)}let R=s.properties[A],M=s.properties[E];I?s=sK(t.helper(sk),[s]):(R&&!s8(R.value)&&(R.value=sK(t.helper(sx),[R.value])),M&&(b||4===M.value.type&&"["===M.value.content.trim()[0]||17===M.value.type)&&(M.value=sK(t.helper(sC),[M.value])));break;case 14:break;default:s=sK(t.helper(sk),[sK(t.helper(sT),[s])])}return{props:s,directives:h,patchFlag:g,dynamicPropNames:k,shouldUseBlock:f}}function ag(e){let t=new Map,n=[];for(let l=0;l<e.length;l++){var r,i;let s=e[l];if(8===s.key.type||!s.key.isStatic){n.push(s);continue}let o=s.key.content,a=t.get(o);a?("style"===o||"class"===o||C(o))&&(r=a,i=s,17===r.value.type?r.value.elements.push(i.value):r.value=sj([r.value,i.value],r.loc)):(t.set(o,s),n.push(s))}return n}function am(e){return"component"===e||"Component"===e}let av=(e,t)=>{if(oh(e)){let{children:n,loc:r}=e,{slotName:i,slotProps:l}=function(e,t){let n,r='"default"',i=[];for(let t=0;t<e.props.length;t++){let n=e.props[t];if(6===n.type)n.value&&("name"===n.name?r=JSON.stringify(n.value.content):(n.name=j(n.name),i.push(n)));else if("bind"===n.name&&oo(n.arg,"name")){if(n.exp)r=n.exp;else if(n.arg&&4===n.arg.type){let e=j(n.arg.content);r=n.exp=sq(e,!1,n.arg.loc)}}else"bind"===n.name&&n.arg&&s8(n.arg)&&(n.arg.content=j(n.arg.content)),i.push(n)}if(i.length>0){let{props:r,directives:l}=af(e,t,i,!1,!1);n=r,l.length&&t.onError(s4(36,l[0].loc))}return{slotName:r,slotProps:n}}(e,t),s=[t.prefixIdentifiers?"_ctx.$slots":"$slots",i,"{}","undefined","true"],o=2;l&&(s[2]=l,o=3),n.length&&(s[3]=sz([],n,!1,!1,r),o=4),t.scopeId&&!t.slotted&&(o=5),s.splice(o),e.codegenNode=sK(t.helper(sy),s,r)}},ay=(e,t,n,r)=>{let i,{loc:l,modifiers:s,arg:o}=e;if(!e.exp&&!s.length,4===o.type)if(o.isStatic){let e=o.content;e.startsWith("vue:")&&(e=`vnode-${e.slice(4)}`),i=sq(0!==t.tagType||e.startsWith("vnode")||!/[A-Z]/.test(e)?W(j(e)):`on:${e}`,!0,o.loc)}else i=sW([`${n.helperString(sE)}(`,o,")"]);else(i=o).children.unshift(`${n.helperString(sE)}(`),i.children.push(")");let a=e.exp;a&&!a.content.trim()&&(a=void 0);let c=n.cacheHandlers&&!a&&!n.inVOnce;if(a){let e,t=or(a),n=!(t||(e=a,oi.test(on(e)))),r=a.content.includes(";");(n||c&&t)&&(a=sW([`${n?"$event":"(...args)"} => ${r?"{":"("}`,a,r?"}":")"]))}let u={props:[sH(i,a||sq("() => {}",!1,l))]};return r&&(u=r(u)),c&&(u.props[0].value=n.cache(u.props[0].value)),u.props.forEach(e=>e.key.isHandlerKey=!0),u},ab=(e,t,n)=>{let{modifiers:r}=e,i=e.arg,{exp:l}=e;return l&&4===l.type&&!l.content.trim()&&(l=void 0),4!==i.type?(i.children.unshift("("),i.children.push(') || ""')):i.isStatic||(i.content=i.content?`${i.content} || ""`:'""'),r.some(e=>"camel"===e.content)&&(4===i.type?i.isStatic?i.content=j(i.content):i.content=`${n.helperString(sN)}(${i.content})`:(i.children.unshift(`${n.helperString(sN)}(`),i.children.push(")"))),!n.inSSR&&(r.some(e=>"prop"===e.content)&&a_(i,"."),r.some(e=>"attr"===e.content)&&a_(i,"^")),{props:[sH(i,l)]}},a_=(e,t)=>{4===e.type?e.isStatic?e.content=t+e.content:e.content=`\`${t}\${${e.content}}\``:(e.children.unshift(`'${t}' + (`),e.children.push(")"))},aS=(e,t)=>{if(0===e.type||1===e.type||11===e.type||10===e.type)return()=>{let n,r=e.children,i=!1;for(let e=0;e<r.length;e++){let t=r[e];if(oa(t)){i=!0;for(let i=e+1;i<r.length;i++){let l=r[i];if(oa(l))n||(n=r[e]=sW([t],t.loc)),n.children.push(" + ",l),r.splice(i,1),i--;else{n=void 0;break}}}}if(i&&(1!==r.length||0!==e.type&&(1!==e.type||0!==e.tagType||e.props.find(e=>7===e.type&&!t.directiveTransforms[e.name]))))for(let e=0;e<r.length;e++){let n=r[e];if(oa(n)||8===n.type){let i=[];(2!==n.type||" "!==n.content)&&i.push(n),t.ssr||0!==oZ(n,t)||i.push("1"),r[e]={type:12,content:n,loc:n.loc,codegenNode:sK(t.helper(su),i)}}}}},ax=new WeakSet,aC=(e,t)=>{if(1===e.type&&ol(e,"once",!0)&&!ax.has(e)&&!t.inVOnce&&!t.inSSR)return ax.add(e),t.inVOnce=!0,t.helper(sI),()=>{t.inVOnce=!1;let e=t.currentNode;e.codegenNode&&(e.codegenNode=t.cache(e.codegenNode,!0,!0))}},ak=(e,t,n)=>{let r,{exp:i,arg:l}=e;if(!i)return n.onError(s4(41,e.loc)),aT();let s=i.loc.source.trim(),o=4===i.type?i.content:s,a=n.bindingMetadata[s];if("props"===a||"props-aliased"===a||"literal-const"===a||"setup-const"===a)return i.loc,aT();if(!o.trim()||!or(i))return n.onError(s4(42,i.loc)),aT();let c=l||sq("modelValue",!0),u=l?s8(l)?`onUpdate:${j(l.content)}`:sW(['"onUpdate:" + ',l]):"onUpdate:modelValue",d=n.isTS?"($event: any)":"$event";r=sW([`${d} => ((`,i,") = $event)"]);let h=[sH(c,e.exp),sH(u,r)];if(e.modifiers.length&&1===t.tagType){let t=e.modifiers.map(e=>e.content).map(e=>(s9.test(e)?JSON.stringify(e):e)+": true").join(", "),n=l?s8(l)?`${l.content}Modifiers`:sW([l,' + "Modifiers"']):"modelModifiers";h.push(sH(n,sq(`{ ${t} }`,!1,e.loc,2)))}return aT(h)};function aT(e=[]){return{props:e}}let aw=new WeakSet,aN=(e,t)=>{if(1===e.type){let n=ol(e,"memo");if(!(!n||aw.has(e))&&!t.inSSR)return aw.add(e),()=>{let r=e.codegenNode||t.currentNode.codegenNode;r&&13===r.type&&(1!==e.tagType&&sG(r,t),e.codegenNode=sK(t.helper(sL),[n.exp,sz(void 0,r),"_cache",String(t.cached.length)]),t.cached.push(null))}}},aA=(e,t)=>{if(1===e.type){for(let n of e.props)if(7===n.type&&"bind"===n.name&&(!n.exp||4===n.exp.type&&!n.exp.content.trim())&&n.arg){let e=n.arg;if(4===e.type&&e.isStatic){let t=j(e.content);(s7.test(t[0])||"-"===t[0])&&(n.exp=sq(t,!1,e.loc))}else t.onError(s4(53,e.loc)),n.exp=sq("",!0,e.loc)}}},aE=Symbol(""),aI=Symbol(""),aR=Symbol(""),aO=Symbol(""),aM=Symbol(""),aP=Symbol(""),aF=Symbol(""),aL=Symbol(""),a$=Symbol(""),aD=Symbol("");Object.getOwnPropertySymbols(r={[aE]:"vModelRadio",[aI]:"vModelCheckbox",[aR]:"vModelText",[aO]:"vModelSelect",[aM]:"vModelDynamic",[aP]:"withModifiers",[aF]:"withKeys",[aL]:"vShow",[a$]:"Transition",[aD]:"TransitionGroup"}).forEach(e=>{sD[e]=r[e]});let aV={parseMode:"html",isVoidTag:ea,isNativeTag:e=>el(e)||es(e)||eo(e),isPreTag:e=>"pre"===e,isIgnoreNewlineTag:e=>"pre"===e||"textarea"===e,decodeEntities:function(e,t=!1){return(f||(f=document.createElement("div")),t)?(f.innerHTML=`<div foo="${e.replace(/"/g,"&quot;")}">`,f.children[0].getAttribute("foo")):(f.innerHTML=e,f.textContent)},isBuiltInComponent:e=>"Transition"===e||"transition"===e?a$:"TransitionGroup"===e||"transition-group"===e?aD:void 0,getNamespace(e,t,n){let r=t?t.ns:n;if(t&&2===r)if("annotation-xml"===t.tag){if("svg"===e)return 1;t.props.some(e=>6===e.type&&"encoding"===e.name&&null!=e.value&&("text/html"===e.value.content||"application/xhtml+xml"===e.value.content))&&(r=0)}else/^m(?:[ions]|text)$/.test(t.tag)&&"mglyph"!==e&&"malignmark"!==e&&(r=0);else t&&1===r&&("foreignObject"===t.tag||"desc"===t.tag||"title"===t.tag)&&(r=0);if(0===r){if("svg"===e)return 1;if("math"===e)return 2}return r}},aB=y("passive,once,capture"),aj=y("stop,prevent,self,ctrl,shift,alt,meta,exact,middle"),aU=y("left,right"),aH=y("onkeyup,onkeydown,onkeypress"),aq=(e,t)=>s8(e)&&"onclick"===e.content.toLowerCase()?sq(t,!0):4!==e.type?sW(["(",e,`) === "onClick" ? "${t}" : (`,e,")"]):e,aW=(e,t)=>{1===e.type&&0===e.tagType&&("script"===e.tag||"style"===e.tag)&&t.removeNode()},aK=[e=>{1===e.type&&e.props.forEach((t,n)=>{let r,i;6===t.type&&"style"===t.name&&t.value&&(e.props[n]={type:7,name:"bind",arg:sq("style",!0,t.loc),exp:(r=t.value.content,i=t.loc,sq(JSON.stringify(er(r)),!1,i,3)),modifiers:[],loc:t.loc})})}],az={cloak:()=>({props:[]}),html:(e,t,n)=>{let{exp:r,loc:i}=e;return r||n.onError(s4(54,i)),t.children.length&&(n.onError(s4(55,i)),t.children.length=0),{props:[sH(sq("innerHTML",!0,i),r||sq("",!0))]}},text:(e,t,n)=>{let{exp:r,loc:i}=e;return r||n.onError(s4(56,i)),t.children.length&&(n.onError(s4(57,i)),t.children.length=0),{props:[sH(sq("textContent",!0),r?oZ(r,n)>0?r:sK(n.helperString(s_),[r],i):sq("",!0))]}},model:(e,t,n)=>{let r=ak(e,t,n);if(!r.props.length||1===t.tagType)return r;e.arg&&n.onError(s4(59,e.arg.loc));let{tag:i}=t,l=n.isCustomElement(i);if("input"===i||"textarea"===i||"select"===i||l){let s=aR,o=!1;if("input"===i||l){let r=os(t,"type");if(r){if(7===r.type)s=aM;else if(r.value)switch(r.value.content){case"radio":s=aE;break;case"checkbox":s=aI;break;case"file":o=!0,n.onError(s4(60,e.loc))}}else t.props.some(e=>7===e.type&&"bind"===e.name&&(!e.arg||4!==e.arg.type||!e.arg.isStatic))&&(s=aM)}else"select"===i&&(s=aO);o||(r.needRuntime=n.helper(s))}else n.onError(s4(58,e.loc));return r.props=r.props.filter(e=>4!==e.key.type||"modelValue"!==e.key.content),r},on:(e,t,n)=>ay(e,t,n,t=>{let{modifiers:r}=e;if(!r.length)return t;let{key:i,value:l}=t.props[0],{keyModifiers:s,nonKeyModifiers:o,eventOptionModifiers:a}=((e,t,n,r)=>{let i=[],l=[],s=[];for(let n=0;n<t.length;n++){let r=t[n].content;aB(r)?s.push(r):aU(r)?s8(e)?aH(e.content.toLowerCase())?i.push(r):l.push(r):(i.push(r),l.push(r)):aj(r)?l.push(r):i.push(r)}return{keyModifiers:i,nonKeyModifiers:l,eventOptionModifiers:s}})(i,r,0,e.loc);if(o.includes("right")&&(i=aq(i,"onContextmenu")),o.includes("middle")&&(i=aq(i,"onMouseup")),o.length&&(l=sK(n.helper(aP),[l,JSON.stringify(o)])),s.length&&(!s8(i)||aH(i.content.toLowerCase()))&&(l=sK(n.helper(aF),[l,JSON.stringify(s)])),a.length){let e=a.map(q).join("");i=s8(i)?sq(`${i.content}${e}`,!0):sW(["(",i,`) + "${e}"`])}return{props:[sH(i,l)]}}),show:(e,t,n)=>{let{exp:r,loc:i}=e;return r||n.onError(s4(62,i)),{props:[],needRuntime:n.helper(aL)}}},aJ=Object.create(null);function aG(e,t){if(!R(e))if(!e.nodeType)return S;else e=e.innerHTML;let n=e+JSON.stringify(t,(e,t)=>"function"==typeof t?t.toString():t),r=aJ[n];if(r)return r;if("#"===e[0]){let t=document.querySelector(e);e=t?t.innerHTML:""}let i=T({hoistStatic:!0,onError:void 0,onWarn:S},t);!i.isCustomElement&&"u">typeof customElements&&(i.isCustomElement=e=>!!customElements.get(e));let{code:l}=function(e,t={}){return function(e,t={}){var n;let r,i=t.onError||s6,l="module"===t.mode;!0===t.prefixIdentifiers?i(s4(48)):l&&i(s4(49)),t.cacheHandlers&&i(s4(50)),t.scopeId&&!l&&i(s4(51));let s=T({},t,{prefixIdentifiers:!1}),o=R(e)?function(e,t){if(oP.reset(),oT=null,ow=null,oN="",oA=-1,oE=-1,oM.length=0,ok=e,ox=T({},oS),t){let e;for(e in t)null!=t[e]&&(ox[e]=t[e])}oP.mode="html"===ox.parseMode?1:2*("sfc"===ox.parseMode),oP.inXML=1===ox.ns||2===ox.ns;let n=t&&t.delimiters;n&&(oP.delimiterOpen=s1(n[0]),oP.delimiterClose=s1(n[1]));let r=oC=function(e,t=""){return{type:0,source:t,children:e,helpers:new Set,components:[],directives:[],hoists:[],imports:[],cached:[],temps:0,codegenNode:void 0,loc:sV}}([],e);return oP.parse(ok),r.loc=oz(0,e.length),r.children=oq(r.children),oC=null,r}(e,s):e,[a,c]=[[aA,aC,an,aN,as,av,ap,au,aS],{on:ay,bind:ab,model:ak}];return r=function(e,{filename:t="",prefixIdentifiers:n=!1,hoistStatic:r=!1,hmr:i=!1,cacheHandlers:l=!1,nodeTransforms:s=[],directiveTransforms:o={},transformHoist:a=null,isBuiltInComponent:c=S,isCustomElement:u=S,expressionPlugins:d=[],scopeId:h=null,slotted:p=!0,ssr:f=!1,inSSR:g=!1,ssrCssVars:m="",bindingMetadata:y=b,inline:_=!1,isTS:x=!1,onError:C=s6,onWarn:k=s3,compatConfig:T}){let w=t.replace(/\?.*$/,"").match(/([^/\\]+)\.\w+$/),N={filename:t,selfName:w&&q(j(w[1])),prefixIdentifiers:n,hoistStatic:r,hmr:i,cacheHandlers:l,nodeTransforms:s,directiveTransforms:o,transformHoist:a,isBuiltInComponent:c,isCustomElement:u,expressionPlugins:d,scopeId:h,slotted:p,ssr:f,inSSR:g,ssrCssVars:m,bindingMetadata:y,inline:_,isTS:x,onError:C,onWarn:k,compatConfig:T,root:e,helpers:new Map,components:new Set,directives:new Set,hoists:[],imports:[],cached:[],constantCache:new WeakMap,vForMemoKeyedNodes:new WeakSet,temps:0,identifiers:Object.create(null),scopes:{vFor:0,vSlot:0,vPre:0,vOnce:0},parent:null,grandParent:null,currentNode:e,childIndex:0,inVOnce:!1,helper(e){let t=N.helpers.get(e)||0;return N.helpers.set(e,t+1),e},removeHelper(e){let t=N.helpers.get(e);if(t){let n=t-1;n?N.helpers.set(e,n):N.helpers.delete(e)}},helperString:e=>`_${sD[N.helper(e)]}`,replaceNode(e){N.parent.children[N.childIndex]=N.currentNode=e},removeNode(e){let t=N.parent.children,n=e?t.indexOf(e):N.currentNode?N.childIndex:-1;e&&e!==N.currentNode?N.childIndex>n&&(N.childIndex--,N.onNodeRemoved()):(N.currentNode=null,N.onNodeRemoved()),N.parent.children.splice(n,1)},onNodeRemoved:S,addIdentifiers(e){},removeIdentifiers(e){},hoist(e){R(e)&&(e=sq(e)),N.hoists.push(e);let t=sq(`_hoisted_${N.hoists.length}`,!1,e.loc,2);return t.hoisted=e,t},cache(e,t=!1,n=!1){let r=function(e,t,n=!1,r=!1){return{type:20,index:e,value:t,needPauseTracking:n,inVOnce:r,needArraySpread:!1,loc:sV}}(N.cached.length,e,t,n);return N.cached.push(r),r}};return N}(o,n=T({},s,{nodeTransforms:[...a,...t.nodeTransforms||[]],directiveTransforms:T({},c,t.directiveTransforms||{})})),o2(o,r),n.hoistStatic&&function e(t,n,r,i=!1,l=!1){let{children:s}=t,o=[];for(let n=0;n<s.length;n++){let a=s[n];if(1===a.type&&0===a.tagType){let e=i?0:oZ(a,r);if(e>0){if(e>=2){a.codegenNode.patchFlag=-1,o.push(a);continue}}else{let e=a.codegenNode;if(13===e.type){let t=e.patchFlag;if((void 0===t||512===t||1===t)&&o0(a,r)>=2){let t=o1(a);t&&(e.props=r.hoist(t))}e.dynamicProps&&(e.dynamicProps=r.hoist(e.dynamicProps))}}}else if(12===a.type&&(i?0:oZ(a,r))>=2){14===a.codegenNode.type&&a.codegenNode.arguments.length>0&&a.codegenNode.arguments.push("-1"),o.push(a);continue}if(1===a.type){let n=1===a.tagType;n&&r.scopes.vSlot++,e(a,t,r,!1,l),n&&r.scopes.vSlot--}else if(11===a.type)e(a,t,r,1===a.children.length,!0);else if(9===a.type)for(let n=0;n<a.branches.length;n++)e(a.branches[n],t,r,1===a.branches[n].children.length,l)}let a=!1;if(o.length===s.length&&1===t.type){if(0===t.tagType&&t.codegenNode&&13===t.codegenNode.type&&E(t.codegenNode.children))t.codegenNode.children=c(sj(t.codegenNode.children)),a=!0;else if(1===t.tagType&&t.codegenNode&&13===t.codegenNode.type&&t.codegenNode.children&&!E(t.codegenNode.children)&&15===t.codegenNode.children.type){let e=u(t.codegenNode,"default");e&&(e.returns=c(sj(e.returns)),a=!0)}else if(3===t.tagType&&n&&1===n.type&&1===n.tagType&&n.codegenNode&&13===n.codegenNode.type&&n.codegenNode.children&&!E(n.codegenNode.children)&&15===n.codegenNode.children.type){let e=ol(t,"slot",!0),r=e&&e.arg&&u(n.codegenNode,e.arg);r&&(r.returns=c(sj(r.returns)),a=!0)}}if(!a)for(let e of o)e.codegenNode=r.cache(e.codegenNode);function c(e){let t=r.cache(e);return t.needArraySpread=!0,t}function u(e,t){if(e.children&&!E(e.children)&&15===e.children.type){let n=e.children.properties.find(e=>e.key===t||e.key.content===t);return n&&n.value}}o.length&&r.transformHoist&&r.transformHoist(s,r,t)}(o,void 0,r,!!oQ(o)),n.ssr||function(e,t){let{helper:n}=t,{children:r}=e;if(1===r.length){let n=oQ(e);if(n&&n.codegenNode){let r=n.codegenNode;13===r.type&&sG(r,t),e.codegenNode=r}else e.codegenNode=r[0]}else r.length>1&&(e.codegenNode=sB(t,n(l7),void 0,e.children,64,void 0,void 0,!0,void 0,!1))}(o,r),o.helpers=new Set([...r.helpers.keys()]),o.components=[...r.components],o.directives=[...r.directives],o.imports=r.imports,o.hoists=r.hoists,o.temps=r.temps,o.cached=r.cached,o.transformed=!0,function(e,t={}){let n=function(e,{mode:t="function",prefixIdentifiers:n="module"===t,sourceMap:r=!1,filename:i="template.vue.html",scopeId:l=null,optimizeImports:s=!1,runtimeGlobalName:o="Vue",runtimeModuleName:a="vue",ssrRuntimeModuleName:c="vue/server-renderer",ssr:u=!1,isTS:d=!1,inSSR:h=!1}){let p={mode:t,prefixIdentifiers:n,sourceMap:r,filename:i,scopeId:l,optimizeImports:s,runtimeGlobalName:o,runtimeModuleName:a,ssrRuntimeModuleName:c,ssr:u,isTS:d,inSSR:h,source:e.source,code:"",column:1,line:1,offset:0,indentLevel:0,pure:!1,map:void 0,helper:e=>`_${sD[e]}`,push(e,t=-2,n){p.code+=e},indent(){f(++p.indentLevel)},deindent(e=!1){e?--p.indentLevel:f(--p.indentLevel)},newline(){f(p.indentLevel)}};function f(e){p.push(`
+`+"  ".repeat(e),0)}return p}(e,t);t.onContextCreated&&t.onContextCreated(n);let{mode:r,push:i,prefixIdentifiers:l,indent:s,deindent:o,newline:a,ssr:c}=n,u=Array.from(e.helpers),d=u.length>0,h=!l&&"module"!==r;!function(e,t){let{push:n,newline:r,runtimeGlobalName:i}=t,l=Array.from(e.helpers);if(l.length>0&&(n(`const _Vue = ${i}
+`,-1),e.hoists.length)){let e=[so,sa,sc,su,sd].filter(e=>l.includes(e)).map(o4).join(", ");n(`const { ${e} } = _Vue
+`,-1)}(function(e,t){if(!e.length)return;t.pure=!0;let{push:n,newline:r}=t;r();for(let i=0;i<e.length;i++){let l=e[i];l&&(n(`const _hoisted_${i+1} = `),o7(l,t),r())}t.pure=!1})(e.hoists,t),r(),n("return ")}(e,n);let p=(c?["_ctx","_push","_parent","_attrs"]:["_ctx","_cache"]).join(", ");if(i(`function ${c?"ssrRender":"render"}(${p}) {`),s(),h&&(i("with (_ctx) {"),s(),d&&(i(`const { ${u.map(o4).join(", ")} } = _Vue
+`,-1),a())),e.components.length&&(o8(e.components,"component",n),(e.directives.length||e.temps>0)&&a()),e.directives.length&&(o8(e.directives,"directive",n),e.temps>0&&a()),e.temps>0){i("let ");for(let t=0;t<e.temps;t++)i(`${t>0?", ":""}_temp${t}`)}return(e.components.length||e.directives.length||e.temps)&&(i(`
+`,0),a()),c||i("return "),e.codegenNode?o7(e.codegenNode,n):i("null"),h&&(o(),i("}")),o(),i("}"),{ast:e,code:n.code,preamble:"",map:n.map?n.map.toJSON():void 0}}(o,s)}(e,T({},aV,t,{nodeTransforms:[aW,...aK,...t.nodeTransforms||[]],directiveTransforms:T({},az,t.directiveTransforms||{}),transformHoist:null}))}(e,i),s=Function(l)();return s._rc=!0,aJ[n]=s}return iP(aG),e.BaseTransition=ny,e.BaseTransitionPropsValidators=ng,e.Comment=r9,e.DeprecationTypes=null,e.EffectScope=em,e.ErrorCodes={SETUP_FUNCTION:0,0:"SETUP_FUNCTION",RENDER_FUNCTION:1,1:"RENDER_FUNCTION",NATIVE_EVENT_HANDLER:5,5:"NATIVE_EVENT_HANDLER",COMPONENT_EVENT_HANDLER:6,6:"COMPONENT_EVENT_HANDLER",VNODE_HOOK:7,7:"VNODE_HOOK",DIRECTIVE_HOOK:8,8:"DIRECTIVE_HOOK",TRANSITION_HOOK:9,9:"TRANSITION_HOOK",APP_ERROR_HANDLER:10,10:"APP_ERROR_HANDLER",APP_WARN_HANDLER:11,11:"APP_WARN_HANDLER",FUNCTION_REF:12,12:"FUNCTION_REF",ASYNC_COMPONENT_LOADER:13,13:"ASYNC_COMPONENT_LOADER",SCHEDULER:14,14:"SCHEDULER",COMPONENT_UPDATE:15,15:"COMPONENT_UPDATE",APP_UNMOUNT_CLEANUP:16,16:"APP_UNMOUNT_CLEANUP"},e.ErrorTypeStrings=null,e.Fragment=r8,e.KeepAlive={name:"KeepAlive",__isKeepAlive:!0,props:{include:[String,RegExp,Array],exclude:[String,RegExp,Array],max:[String,Number]},setup(e,{slots:t}){let n=iA(),r=n.ctx,i=new Map,l=new Set,s=null,o=n.suspense,{renderer:{p:a,m:c,um:u,o:{createElement:d}}}=r,h=d("div");function p(e){nG(e),u(e,n,o,!0)}function f(e){i.forEach((t,n)=>{let r=iV(nU(t)?t.type.__asyncResolved||{}:t.type);r&&!e(r)&&g(n)})}function g(e){let t=i.get(e);!t||s&&iu(t,s)?s&&nG(s):p(t),i.delete(e),l.delete(e)}r.activate=(e,t,n,r,i)=>{let l=e.component;c(e,t,n,0,o),a(l.vnode,e,t,n,l,o,r,e.slotScopeIds,i),rW(()=>{l.isDeactivated=!1,l.a&&z(l.a);let t=e.props&&e.props.onVnodeMounted;t&&ik(t,l.parent,e)},o)},r.deactivate=e=>{let t=e.component;rZ(t.m),rZ(t.a),c(e,h,null,1,o),rW(()=>{t.da&&z(t.da);let n=e.props&&e.props.onVnodeUnmounted;n&&ik(n,t.parent,e),t.isDeactivated=!0},o)},t7(()=>[e.include,e.exclude],([e,t])=>{e&&f(t=>nW(e,t)),t&&f(e=>!nW(t,e))},{flush:"post",deep:!0});let m=null,y=()=>{null!=m&&(rY(n.subTree.type)?rW(()=>{i.set(m,nX(n.subTree))},n.subTree.suspense):i.set(m,nX(n.subTree)))};return n0(y),n2(y),n6(()=>{i.forEach(e=>{let{subTree:t,suspense:r}=n,i=nX(t);if(e.type===i.type&&e.key===i.key){nG(i);let e=i.component.da;e&&rW(e,r);return}p(e)})}),()=>{if(m=null,!t.default)return s=null;let n=t.default(),r=n[0];if(n.length>1)return s=null,n;if(!ic(r)||!(4&r.shapeFlag)&&!(128&r.shapeFlag))return s=null,r;let o=nX(r);if(o.type===r9)return s=null,o;let a=o.type,c=iV(nU(o)?o.type.__asyncResolved||{}:a),{include:u,exclude:d,max:h}=e;if(u&&(!c||!nW(u,c))||d&&c&&nW(d,c))return o.shapeFlag&=-257,s=o,r;let p=null==o.key?a:o.key,f=i.get(p);return o.el&&(o=iv(o),128&r.shapeFlag&&(r.ssContent=o)),m=p,f?(o.el=f.el,o.component=f.component,o.transition&&nC(o,o.transition),o.shapeFlag|=512,l.delete(p),l.add(p)):(l.add(p),h&&l.size>parseInt(h,10)&&g(l.values().next().value)),o.shapeFlag|=256,s=o,rY(r.type)?r:o}}},e.ReactiveEffect=ey,e.Static=r7,e.Suspense={name:"Suspense",__isSuspense:!0,process(e,t,n,r,i,l,s,o,a,c){if(null==e)!function(e,t,n,r,i,l,s,o,a){let{p:c,o:{createElement:u}}=a,d=u("div"),h=e.suspense=r2(e,i,r,t,d,n,l,s,o,a);c(null,h.pendingBranch=e.ssContent,d,null,r,h,l,s),h.deps>0?(r1(e,"onPending"),r1(e,"onFallback"),c(null,e.ssFallback,t,n,r,null,l,s),r4(h,e.ssFallback)):h.resolve(!1,!0)}(t,n,r,i,l,s,o,a,c);else{if(l&&l.deps>0&&!e.suspense.isInFallback){t.suspense=e.suspense,t.suspense.vnode=t,t.el=e.el;return}!function(e,t,n,r,i,l,s,o,{p:a,um:c,o:{createElement:u}}){let d=t.suspense=e.suspense;d.vnode=t,t.el=e.el;let h=t.ssContent,p=t.ssFallback,{activeBranch:f,pendingBranch:g,isInFallback:m,isHydrating:y}=d;if(g)d.pendingBranch=h,iu(g,h)?(a(g,h,d.hiddenContainer,null,i,d,l,s,o),d.deps<=0?d.resolve():m&&!y&&(a(f,p,n,r,i,null,l,s,o),r4(d,p))):(d.pendingId=r0++,y?(d.isHydrating=!1,d.activeBranch=g):c(g,i,d),d.deps=0,d.effects.length=0,d.hiddenContainer=u("div"),m?(a(null,h,d.hiddenContainer,null,i,d,l,s,o),d.deps<=0?d.resolve():(a(f,p,n,r,i,null,l,s,o),r4(d,p))):f&&iu(f,h)?(a(f,h,n,r,i,d,l,s,o),d.resolve(!0)):(a(null,h,d.hiddenContainer,null,i,d,l,s,o),d.deps<=0&&d.resolve()));else if(f&&iu(f,h))a(f,h,n,r,i,d,l,s,o),r4(d,h);else if(r1(t,"onPending"),d.pendingBranch=h,512&h.shapeFlag?d.pendingId=h.component.suspenseId:d.pendingId=r0++,a(null,h,d.hiddenContainer,null,i,d,l,s,o),d.deps<=0)d.resolve();else{let{timeout:e,pendingId:t}=d;e>0?setTimeout(()=>{d.pendingId===t&&d.fallback(p)},e):0===e&&d.fallback(p)}}(e,t,n,r,i,s,o,a,c)}},hydrate:function(e,t,n,r,i,l,s,o,a){let c=t.suspense=r2(t,r,n,e.parentNode,document.createElement("div"),null,i,l,s,o,!0),u=a(e,c.pendingBranch=t.ssContent,n,c,l,s);return 0===c.deps&&c.resolve(!1,!0),u},normalize:function(e){let{shapeFlag:t,children:n}=e,r=32&t;e.ssContent=r6(r?n.default:n),e.ssFallback=r?r6(n.fallback):ig(r9)}},e.Teleport={name:"Teleport",__isTeleport:!0,process(e,t,n,r,i,l,s,o,a,c){let{mc:u,pc:d,pbc:h,o:{insert:p,querySelector:f,createText:g,parentNode:m}}=c,y=ni(t.props),{dynamicChildren:b}=t,_=(e,t,n)=>{16&e.shapeFlag&&u(e.children,t,n,i,l,s,o,a)},S=(e=t)=>{let n=ni(e.props),r=e.target=no(e.props,f),l=nu(r,e,g,p);r&&("svg"!==s&&nl(r)?s="svg":"mathml"!==s&&ns(r)&&(s="mathml"),i&&i.isCE&&(i.ce._teleportTargets||(i.ce._teleportTargets=new Set)).add(r),n||(_(e,r,l),nc(e,!1)))},x=e=>{let t=()=>{if(nn.get(e)===t){if(nn.delete(e),ni(e.props)){let t=m(e.el)||n;_(e,t,e.anchor),nc(e,!0)}S(e)}};nn.set(e,t),rW(t,l)};if(null==e){let e,i=t.el=g(""),s=t.anchor=g("");if(p(i,n,r),p(s,n,r),(e=t.props)&&(e.defer||""===e.defer)||l&&l.pendingBranch)return void x(t);y&&(_(t,n,s),nc(t,!0)),S()}else{t.el=e.el;let r=t.anchor=e.anchor,u=nn.get(e);if(u){u.flags|=8,nn.delete(e),x(t);return}t.targetStart=e.targetStart;let p=t.target=e.target,g=t.targetAnchor=e.targetAnchor,m=ni(e.props),_=m?n:p,S=m?r:g;if("svg"===s||nl(p)?s="svg":("mathml"===s||ns(p))&&(s="mathml"),b?(h(e.dynamicChildren,b,_,i,l,s,o),rQ(e,t,!0)):a||d(e,t,_,S,i,l,s,o,!1),y)m?t.props&&e.props&&t.props.to!==e.props.to&&(t.props.to=e.props.to):na(t,n,r,c,1);else if((t.props&&t.props.to)!==(e.props&&e.props.to)){let e=no(t.props,f);e&&(t.target=e,na(t,e,null,c,0))}else m&&na(t,p,g,c,1);nc(t,y)}},remove(e,t,n,{um:r,o:{remove:i}},l){let{shapeFlag:s,children:o,anchor:a,targetStart:c,targetAnchor:u,target:d,props:h}=e,p=ni(h),f=l||!p,g=nn.get(e);if(g&&(g.flags|=8,nn.delete(e)),d&&(i(c),i(u)),l&&i(a),!g&&(p||d)&&16&s)for(let e=0;e<o.length;e++){let i=o[e];r(i,t,n,f,!!i.dynamicChildren)}},move:na,hydrate:function(e,t,n,r,i,l,{o:{nextSibling:s,parentNode:o,querySelector:a,insert:c,createText:u}},d){function h(e,n){let r=n;for(;r;){if(r&&8===r.nodeType){if("teleport start anchor"===r.data)t.targetStart=r;else if("teleport anchor"===r.data){t.targetAnchor=r,e._lpa=t.targetAnchor&&s(t.targetAnchor);break}}r=s(r)}}function p(e,t){t.anchor=d(s(e),t,o(e),n,r,i,l)}let f=t.target=no(t.props,a),g=ni(t.props);if(f){let a=f._lpa||f.firstChild;16&t.shapeFlag&&(g?(p(e,t),h(f,a),t.targetAnchor||nu(f,t,u,c,o(e)===f?e:null)):(t.anchor=s(e),h(f,a),t.targetAnchor||nu(f,t,u,c),d(a&&s(a),t,f,n,r,i,l))),nc(t,g)}else g&&16&t.shapeFlag&&(p(e,t),t.targetStart=e,t.targetAnchor=s(e));return t.anchor&&s(t.anchor)}},e.Text=r5,e.TrackOpTypes={GET:"get",HAS:"has",ITERATE:"iterate"},e.Transition=i0,e.TransitionGroup=lM,e.TriggerOpTypes={SET:"set",ADD:"add",DELETE:"delete",CLEAR:"clear"},e.VueElement=lN,e.assertNumber=function(e,t){},e.callWithAsyncErrorHandling=tD,e.callWithErrorHandling=t$,e.camelize=j,e.capitalize=q,e.cloneVNode=iv,e.compatUtils=null,e.compile=aG,e.computed=iB,e.createApp=l4,e.createBlock=ia,e.createCommentVNode=ib,e.createElementBlock=function(e,t,n,r,i,l){return io(ip(e,t,n,r,i,l,!0))},e.createElementVNode=ip,e.createHydrationRenderer=rK,e.createPropsRestProxy=function(e,t){let n={};for(let r in e)t.includes(r)||Object.defineProperty(n,r,{enumerable:!0,get:()=>e[r]});return n},e.createRenderer=function(e){return rz(e)},e.createSSRApp=l8,e.createSlots=function(e,t){for(let n=0;n<t.length;n++){let r=t[n];if(E(r))for(let t=0;t<r.length;t++)e[r[t].name]=r[t].fn;else r&&(e[r.name]=r.key?(...e)=>{let t=r.fn(...e);return t&&(t.key=r.key),t}:r.fn)}return e},e.createStaticVNode=function(e,t){let n=ig(r7,null,e);return n.staticCount=t,n},e.createTextVNode=iy,e.createVNode=ig,e.customRef=tE,e.defineAsyncComponent=function(e){let t;I(e)&&(e={loader:e});let{loader:n,loadingComponent:r,errorComponent:i,delay:l=200,hydrate:s,timeout:o,suspensible:a=!0,onError:c}=e,u=null,d=0,h=()=>{let e;return u||(e=u=n().catch(e=>{if(e=e instanceof Error?e:Error(String(e)),c)return new Promise((t,n)=>{c(e,()=>t((d++,u=null,h())),()=>n(e),d+1)});throw e}).then(n=>e!==u&&u?u:(n&&(n.__esModule||"Module"===n[Symbol.toStringTag])&&(n=n.default),t=n,n)))};return nT({name:"AsyncComponentWrapper",__asyncLoader:h,__asyncHydrate(e,n,r){let i=!1;(n.bu||(n.bu=[])).push(()=>i=!0);let l=()=>{i||r()},o=s?()=>{let t=s(l,t=>(function(e,t){if(nP(e)&&"["===e.data){let n=1,r=e.nextSibling;for(;r;){if(1===r.nodeType){if(!1===t(r))break}else if(nP(r))if("]"===r.data){if(0==--n)break}else"["===r.data&&n++;r=r.nextSibling}}else t(e)})(e,t));t&&(n.bum||(n.bum=[])).push(t)}:l;t?o():h().then(()=>!n.isUnmounted&&o())},get __asyncResolved(){return t},setup(){let e,n,s=iN;if(nw(s),t)return()=>nH(t,s);let c=e=>{u=null,tV(e,s,13,!i)};if(a&&s.suspense)return h().then(e=>()=>nH(e,s)).catch(e=>(c(e),()=>i?ig(i,{error:e}):null));let d=tS(!1),p=tS(),f=tS(!!l);return n3(()=>{null!=e&&clearTimeout(e),null!=n&&clearTimeout(n)}),l&&(n=setTimeout(()=>{s.isUnmounted||(f.value=!1)},l)),null!=o&&(e=setTimeout(()=>{if(!s.isUnmounted&&!d.value&&!p.value){let e=Error(`Async component timed out after ${o}ms.`);c(e),p.value=e}},o)),h().then(()=>{!s.isUnmounted&&(d.value=!0,s.parent&&nq(s.parent.vnode)&&s.parent.update())}).catch(e=>{if(s.isUnmounted){u=null;return}c(e),p.value=e}),()=>d.value&&t?nH(t,s):p.value&&i?ig(i,{error:p.value}):r&&!f.value?nH(r,s):void 0}})},e.defineComponent=nT,e.defineCustomElement=lT,e.defineEmits=function(){return null},e.defineExpose=function(e){},e.defineModel=function(){},e.defineOptions=function(e){},e.defineProps=function(){return null},e.defineSSRCustomElement=(e,t)=>lT(e,t,l8),e.defineSlots=function(){return null},e.devtools=void 0,e.effect=function(e,t){e.effect instanceof ey&&(e=e.effect.fn);let n=new ey(e);t&&T(n,t);try{n.run()}catch(e){throw n.stop(),e}let r=n.run.bind(n);return r.effect=n,r},e.effectScope=function(e){return new em(e)},e.getCurrentInstance=iA,e.getCurrentScope=function(){return l},e.getCurrentWatcher=function(){return g},e.getTransitionRawChildren=nk,e.guardReactiveProps=im,e.h=ij,e.handleError=tV,e.hasInjectionContext=function(){return!!(iA()||rx)},e.hydrate=(...e)=>{l6().hydrate(...e)},e.hydrateOnIdle=(e=1e4)=>t=>{let n=nB(t,{timeout:e});return()=>nj(n)},e.hydrateOnInteraction=(e=[])=>(t,n)=>{R(e)&&(e=[e]);let r=!1,i=e=>{r||(r=!0,l(),t(),e.target.dispatchEvent(new e.constructor(e.type,e)))},l=()=>{n(t=>{for(let n of e)t.removeEventListener(n,i)})};return n(t=>{for(let n of e)t.addEventListener(n,i,{once:!0})}),l},e.hydrateOnMediaQuery=e=>t=>{if(e){let n=matchMedia(e);if(!n.matches)return n.addEventListener("change",t,{once:!0}),()=>n.removeEventListener("change",t);t()}},e.hydrateOnVisible=e=>(t,n)=>{let r=new IntersectionObserver(e=>{for(let n of e)if(n.isIntersecting){r.disconnect(),t();break}},e);return n(e=>{if(e instanceof Element){if(function(e){let{top:t,left:n,bottom:r,right:i}=e.getBoundingClientRect(),{innerHeight:l,innerWidth:s}=window;return(t>0&&t<l||r>0&&r<l)&&(n>0&&n<s||i>0&&i<s)}(e))return t(),r.disconnect(),!1;r.observe(e)}}),()=>r.disconnect()},e.initCustomFormatter=function(){},e.initDirectivesForSSR=S,e.inject=t8,e.isMemoSame=iU,e.isProxy=tg,e.isReactive=th,e.isReadonly=tp,e.isRef=t_,e.isRuntimeOnly=()=>!d,e.isShallow=tf,e.isVNode=ic,e.markRaw=tv,e.mergeDefaults=function(e,t){let n=rc(e);for(let e in t){if(e.startsWith("__skip"))continue;let r=n[e];r?E(r)||I(r)?r=n[e]={type:r,default:t[e]}:r.default=t[e]:null===r&&(r=n[e]={default:t[e]}),r&&t[`__skip_${e}`]&&(r.skipFactory=!0)}return n},e.mergeModels=function(e,t){return e&&t?E(e)&&E(t)?e.concat(t):T({},rc(e),rc(t)):e||t},e.mergeProps=iC,e.nextTick=tz,e.nodeOps=iJ,e.normalizeClass=ei,e.normalizeProps=function(e){if(!e)return null;let{class:t,style:n}=e;return t&&!R(t)&&(e.class=ei(t)),n&&(e.style=Y(n)),e},e.normalizeStyle=Y,e.onActivated=nK,e.onBeforeMount=nY,e.onBeforeUnmount=n6,e.onBeforeUpdate=n1,e.onDeactivated=nz,e.onErrorCaptured=n9,e.onMounted=n0,e.onRenderTracked=n5,e.onRenderTriggered=n8,e.onScopeDispose=function(e,t=!1){l&&l.cleanups.push(e)},e.onServerPrefetch=n4,e.onUnmounted=n3,e.onUpdated=n2,e.onWatcherCleanup=tF,e.openBlock=ir,e.patchProp=lC,e.popScopeId=function(){t1=null},e.provide=t4,e.proxyRefs=tN,e.pushScopeId=function(e){t1=e},e.queuePostFlushCb=tX,e.reactive=ta,e.readonly=tu,e.ref=tS,e.registerRuntimeCompiler=iP,e.render=l3,e.renderList=function(e,t,n,r){let i,l=n&&n[r],s=E(e);if(s||R(e)){let n=s&&th(e),r=!1,o=!1;n&&(r=!tf(e),o=tp(e),e=eU(e)),i=Array(e.length);for(let n=0,s=e.length;n<s;n++)i[n]=t(r?o?tb(ty(e[n])):ty(e[n]):e[n],n,void 0,l&&l[n])}else if("number"==typeof e){i=Array(e);for(let n=0;n<e;n++)i[n]=t(n+1,n,void 0,l&&l[n])}else if(M(e))if(e[Symbol.iterator])i=Array.from(e,(e,n)=>t(e,n,void 0,l&&l[n]));else{let n=Object.keys(e);i=Array(n.length);for(let r=0,s=n.length;r<s;r++){let s=n[r];i[r]=t(e[s],s,r,l&&l[r])}}else i=[];return n&&(n[r]=i),i},e.renderSlot=function(e,t,n={},r,i){if(t0.ce||t0.parent&&nU(t0.parent)&&t0.parent.ce){let e=Object.keys(n).length>0;return"default"!==t&&(n.name=t),ir(),ia(r8,null,[ig("slot",n,r&&r())],e?-2:64)}let l=e[t];l&&l._c&&(l._d=!1),ir();let s=l&&function e(t){return t.some(t=>!ic(t)||t.type!==r9&&(t.type!==r8||!!e(t.children)))?t:null}(l(n)),o=n.key||s&&s.key,a=ia(r8,{key:(o&&!O(o)?o:`_${t}`)+(!s&&r?"_fb":"")},s||(r?r():[]),s&&1===e._?64:-2);return!i&&a.scopeId&&(a.slotScopeIds=[a.scopeId+"-s"]),l&&l._c&&(l._d=!0),a},e.resolveComponent=function(e,t){return rt(n7,e,!0,t)||e},e.resolveDirective=function(e){return rt("directives",e)},e.resolveDynamicComponent=function(e){return R(e)?rt(n7,e,!1)||e:e||re},e.resolveFilter=null,e.resolveTransitionHooks=n_,e.setBlockTracking=is,e.setDevtoolsHook=S,e.setTransitionHooks=nC,e.shallowReactive=tc,e.shallowReadonly=function(e){return td(e,!0,e8,tr,to)},e.shallowRef=tx,e.ssrContextKey=t5,e.ssrUtils=null,e.stop=function(e){e.effect.stop()},e.toDisplayString=ep,e.toHandlerKey=W,e.toHandlers=function(e,t){let n={};for(let r in e)n[t&&/[A-Z]/.test(r)?`on:${r}`:W(r)]=e[r];return n},e.toRaw=tm,e.toRef=function(e,t,n){if(t_(e))return e;if(I(e))return new tR(e);if(!M(e)||!(arguments.length>1))return tS(e);return new tI(e,t,n)},e.toRefs=function(e){let t=E(e)?Array(e.length):{};for(let n in e)t[n]=new tI(e,n,void 0);return t},e.toValue=function(e){return I(e)?e():tT(e)},e.transformVNodeArgs=function(e){},e.triggerRef=function(e){e.dep&&e.dep.trigger()},e.unref=tT,e.useAttrs=function(){return ra().attrs},e.useCssModule=function(e="$style"){return b},e.useCssVars=function(e){let t=iA();if(!t)return;let n=t.ut=(n=e(t.proxy))=>{Array.from(document.querySelectorAll(`[data-v-owner="${t.uid}"]`)).forEach(e=>lo(e,n))},r=()=>{let r=e(t.proxy);t.ce?lo(t.ce,r):function e(t,n){if(128&t.shapeFlag){let r=t.suspense;t=r.activeBranch,r.pendingBranch&&!r.isHydrating&&r.effects.push(()=>{e(r.activeBranch,n)})}for(;t.component;)t=t.component.subTree;if(1&t.shapeFlag&&t.el)lo(t.el,n);else if(t.type===r8)t.children.forEach(t=>e(t,n));else if(t.type===r7){let{el:e,anchor:r}=t;for(;e&&(lo(e,n),e!==r);)e=e.nextSibling}}(t.subTree,r),n(r)};n1(()=>{tX(r)}),n0(()=>{t7(r,S,{flush:"post"});let e=new MutationObserver(r);e.observe(t.subTree.el.parentNode,{childList:!0}),n3(()=>e.disconnect())})},e.useHost=lA,e.useId=function(){let e=iA();return e?(e.appContext.config.idPrefix||"v")+"-"+e.ids[0]+e.ids[1]++:""},e.useModel=function(e,t,n=b){let r=iA(),i=j(t),l=H(t),s=rC(e,i),o=tE((s,o)=>{let a,c,u=b;return t9(()=>{let t=e[i];K(a,t)&&(a=t,o())}),{get:()=>(s(),n.get?n.get(a):a),set(e){let s=n.set?n.set(e):e;if(!K(s,a)&&!(u!==b&&K(e,u)))return;let d=r.vnode.props,h=!!(d&&(t in d||i in d||l in d)&&(`onUpdate:${t}`in d||`onUpdate:${i}`in d||`onUpdate:${l}`in d));h||(a=e,o()),r.emit(`update:${t}`,s),K(e,u)&&(K(e,s)&&!K(s,c)||h&&u!==b&&!K(s,a))&&o(),u=e,c=s}}});return o[Symbol.iterator]=()=>{let e=0;return{next:()=>e<2?{value:e++?s||b:o,done:!1}:{done:!0}}},o},e.useSSRContext=()=>{},e.useShadowRoot=function(){let e=lA();return e&&e.shadowRoot},e.useSlots=function(){return ra().slots},e.useTemplateRef=function(e){let t=iA(),n=tx(null);return t&&Object.defineProperty(t.refs===b?t.refs={}:t.refs,e,{enumerable:!0,get:()=>n.value,set:e=>n.value=e}),n},e.useTransitionState=np,e.vModelCheckbox=lq,e.vModelDynamic={created(e,t,n){lQ(e,t,n,null,"created")},mounted(e,t,n){lQ(e,t,n,null,"mounted")},beforeUpdate(e,t,n,r){lQ(e,t,n,r,"beforeUpdate")},updated(e,t,n,r){lQ(e,t,n,r,"updated")}},e.vModelRadio=lK,e.vModelSelect=lz,e.vModelText=lH,e.vShow={name:"show",beforeMount(e,{value:t},{transition:n}){e[lr]="none"===e.style.display?"":e.style.display,n&&t?n.beforeEnter(e):ll(e,t)},mounted(e,{value:t},{transition:n}){n&&t&&n.enter(e)},updated(e,{value:t,oldValue:n},{transition:r}){!t!=!n&&(r?t?(r.beforeEnter(e),ll(e,!0),r.enter(e)):r.leave(e,()=>{ll(e,!1)}):ll(e,t))},beforeUnmount(e,{value:t}){ll(e,t)}},e.version=iH,e.warn=S,e.watch=function(e,t,n){return t7(e,t,n)},e.watchEffect=function(e,t){return t7(e,null,t)},e.watchPostEffect=function(e,t){return t7(e,null,{flush:"post"})},e.watchSyncEffect=t9,e.withAsyncContext=function(e){let t=iA(),n=iO,r=e();iI(),n&&u(!1);let i=()=>{iE(t),n&&u(!0)},l=()=>{iA()!==t&&t.scope.off(),iI(),n&&u(!1)};return P(r)&&(r=r.catch(e=>{throw i(),Promise.resolve().then(()=>Promise.resolve().then(l)),e})),[r,()=>{i(),Promise.resolve().then(l)}]},e.withCtx=t6,e.withDefaults=function(e,t){return null},e.withDirectives=function(e,t){if(null===t0)return e;let n=iD(t0),r=e.dirs||(e.dirs=[]);for(let e=0;e<t.length;e++){let[i,l,s,o=b]=t[e];i&&(I(i)&&(i={mounted:i,updated:i}),i.deep&&tL(l),r.push({dir:i,instance:n,value:l,oldValue:void 0,arg:s,modifiers:o}))}return e},e.withKeys=(e,t)=>{let n=e._withKeys||(e._withKeys={}),r=t.join(".");return n[r]||(n[r]=n=>{if(!("key"in n))return;let r=H(n.key);if(t.some(e=>e===r||l0[e]===r))return e(n)})},e.withMemo=function(e,t,n,r){let i=n[r];if(i&&iU(i,e))return i;let l=t();return l.memo=e.slice(),l.cacheIndex=r,n[r]=l},e.withModifiers=(e,t)=>{if(!e)return e;let n=e._withMods||(e._withMods={}),r=t.join(".");return n[r]||(n[r]=(n,...r)=>{for(let e=0;e<t.length;e++){let r=lY[t[e]];if(r&&r(n,t))return}return e(n,...r)})},e.withScopeId=e=>t6,e}({});
+
+</script>
 <script>
 const { createApp, reactive, computed, ref } = Vue;
 
 createApp({
   setup() {
-    const view = ref('setup')
-    const currentUser = ref(null)
-    const trips = ref([])
-    const currentTripId = ref(null)
-    const showAddTrip = ref(false)
-    const showAddTransaction = ref(false)
+    const view = ref('setup');
+    const currentUser = ref(null);
+    const trips = ref([]);
+    const currentTripId = ref(null);
+    const showAddTrip = ref(false);
+    const showAddTransaction = ref(false);
+    const showInstallBanner = ref(false);
 
-    const setupForm = reactive({ name: '', email: '' })
-    const tripForm = reactive({ title: '', text: '', participantInput: '', participants: [] })
-    const transactionForm = reactive({ email: '', title: '', cost: '' })
+    const setupForm = reactive({ name: '', email: '' });
+    const tripForm  = reactive({ title: '', text: '', participantInput: '', participants: [] });
+    const transactionForm = reactive({ email: '', title: '', cost: '' });
 
-    // ── localStorage helpers ──────────────────────────────────────
-    const saveTrips = () => {
-      localStorage.setItem('urunan_trips', JSON.stringify(trips.value))
-    }
+    // ── Persistence ────────────────────────────────────────────
+    const saveTrips = () => localStorage.setItem('urunan_trips', JSON.stringify(trips.value));
 
-    // ── Init: restore saved session ───────────────────────────────
-    const savedUser = localStorage.getItem('urunan_user')
+    // ── Init ───────────────────────────────────────────────────
+    const savedUser = localStorage.getItem('urunan_user');
     if (savedUser) {
-      currentUser.value = JSON.parse(savedUser)
-      const savedTrips = localStorage.getItem('urunan_trips')
-      trips.value = savedTrips ? JSON.parse(savedTrips) : []
-      view.value = 'trips'
+      currentUser.value = JSON.parse(savedUser);
+      const saved = localStorage.getItem('urunan_trips');
+      trips.value = saved ? JSON.parse(saved) : [];
+      view.value = 'trips';
+      // Show install hint once (not in standalone mode)
+      const standalone = window.navigator.standalone || window.matchMedia('(display-mode: standalone)').matches;
+      if (!standalone && !localStorage.getItem('urunan_install_dismissed')) {
+        showInstallBanner.value = true;
+      }
     }
 
-    // ── Setup ────────────────────────────────────────────────────
+    const dismissInstallBanner = () => {
+      showInstallBanner.value = false;
+      localStorage.setItem('urunan_install_dismissed', '1');
+    };
+
+    // ── Setup ──────────────────────────────────────────────────
     const completeSetup = () => {
-      currentUser.value = { name: setupForm.name.trim(), email: setupForm.email.trim().toLowerCase() }
-      localStorage.setItem('urunan_user', JSON.stringify(currentUser.value))
-      view.value = 'trips'
-    }
+      currentUser.value = { name: setupForm.name.trim(), email: setupForm.email.trim().toLowerCase() };
+      localStorage.setItem('urunan_user', JSON.stringify(currentUser.value));
+      const standalone = window.navigator.standalone || window.matchMedia('(display-mode: standalone)').matches;
+      if (!standalone) showInstallBanner.value = true;
+      view.value = 'trips';
+    };
 
     const logout = () => {
-      if (!confirm('Log out? Your data will remain saved on this device.')) return
-      currentUser.value = null
-      localStorage.removeItem('urunan_user')
-      setupForm.name = ''
-      setupForm.email = ''
-      view.value = 'setup'
-    }
+      if (!confirm('Log out? Your trips will remain saved on this device.')) return;
+      currentUser.value = null;
+      localStorage.removeItem('urunan_user');
+      setupForm.name = ''; setupForm.email = '';
+      view.value = 'setup';
+    };
 
-    // ── Trip List ─────────────────────────────────────────────────
-    const myTrips = computed(() => {
-      if (!currentUser.value) return []
-      return trips.value.filter(t =>
-        t.users.some(u => u.email === currentUser.value.email)
-      )
-    })
+    // ── Trip List ──────────────────────────────────────────────
+    const myTrips = computed(() =>
+      !currentUser.value ? [] :
+      trips.value.filter(t => t.users.some(u => u.email === currentUser.value.email))
+    );
 
-    const tripTotal = (trip) =>
-      trip.transactions.reduce((sum, tx) => sum + tx.cost, 0)
+    const tripTotal = t => t.transactions.reduce((s, tx) => s + tx.cost, 0);
 
     const addParticipant = () => {
-      const email = tripForm.participantInput.trim().toLowerCase()
-      if (!email) return
-      if (email === currentUser.value.email) {
-        tripForm.participantInput = ''
-        return
-      }
-      if (!tripForm.participants.find(p => p.email === email)) {
-        tripForm.participants.push({ email })
-      }
-      tripForm.participantInput = ''
-    }
+      const email = tripForm.participantInput.trim().toLowerCase();
+      if (!email) return;
+      if (email !== currentUser.value.email && !tripForm.participants.find(p => p.email === email))
+        tripForm.participants.push({ email });
+      tripForm.participantInput = '';
+    };
 
-    const removeParticipant = (email) => {
-      tripForm.participants = tripForm.participants.filter(p => p.email !== email)
-    }
+    const removeParticipant = email => {
+      tripForm.participants = tripForm.participants.filter(p => p.email !== email);
+    };
 
     const createTrip = () => {
-      const users = [
-        { email: currentUser.value.email },
-        ...tripForm.participants
-      ]
       trips.value.push({
         id: Date.now(),
         title: tripForm.title.trim(),
-        text: tripForm.text.trim(),
+        text:  tripForm.text.trim(),
         is_resolved: false,
-        users,
+        users: [{ email: currentUser.value.email }, ...tripForm.participants],
         transactions: []
-      })
-      saveTrips()
-      tripForm.title = ''
-      tripForm.text = ''
-      tripForm.participantInput = ''
-      tripForm.participants = []
-      showAddTrip.value = false
-    }
+      });
+      saveTrips();
+      Object.assign(tripForm, { title: '', text: '', participantInput: '', participants: [] });
+      showAddTrip.value = false;
+    };
 
-    const confirmDeleteTrip = (tripId) => {
-      if (!confirm('Delete this trip and all its transactions?')) return
-      trips.value = trips.value.filter(t => t.id !== tripId)
-      saveTrips()
-    }
+    const confirmDeleteTrip = id => {
+      if (!confirm('Delete this trip and all its transactions?')) return;
+      trips.value = trips.value.filter(t => t.id !== id);
+      saveTrips();
+    };
 
-    const openTrip = (tripId) => {
-      currentTripId.value = tripId
-      showAddTransaction.value = false
-      transactionForm.email = ''
-      transactionForm.title = ''
-      transactionForm.cost = ''
-      view.value = 'trip-detail'
-    }
+    const openTrip = id => {
+      currentTripId.value = id;
+      showAddTransaction.value = false;
+      Object.assign(transactionForm, { email: '', title: '', cost: '' });
+      view.value = 'trip-detail';
+    };
 
-    // ── Trip Detail ───────────────────────────────────────────────
-    const currentTrip = computed(() =>
-      trips.value.find(t => t.id === currentTripId.value) || null
-    )
+    // ── Trip Detail ────────────────────────────────────────────
+    const currentTrip = computed(() => trips.value.find(t => t.id === currentTripId.value) || null);
 
     const myPaid = computed(() => {
-      if (!currentTrip.value || !currentUser.value) return 0
+      if (!currentTrip.value || !currentUser.value) return 0;
       return currentTrip.value.transactions
         .filter(tx => tx.email === currentUser.value.email)
-        .reduce((sum, tx) => sum + tx.cost, 0)
-    })
+        .reduce((s, tx) => s + tx.cost, 0);
+    });
 
-    // Ported from frontend/src/views/TripDetail.vue (with bug fix on userDebt key)
+    // Debt minimisation — ported from TripDetail.vue (bug-fixed)
     const mappedDebt = computed(() => {
-      if (!currentTrip.value) return []
-      const trip = currentTrip.value
+      if (!currentTrip.value) return [];
+      const trip = currentTrip.value;
 
-      const userExpenses = {}
-      trip.users.forEach(u => { userExpenses[u.email] = 0 })
-      trip.transactions.forEach(tx => {
-        tx.details.forEach(portion => {
-          userExpenses[portion.email] = (userExpenses[portion.email] || 0) + portion.cost
-        })
-      })
+      const spent = {};
+      trip.users.forEach(u => (spent[u.email] = 0));
+      trip.transactions.forEach(tx =>
+        tx.details.forEach(d => { spent[d.email] = (spent[d.email] || 0) + d.cost; })
+      );
 
-      const userDebt = {}
+      const net = {};
       trip.users.forEach(u => {
-        const totalPaid = trip.transactions
-          .filter(tx => tx.email === u.email)
-          .reduce((sum, tx) => sum + tx.cost, 0)
-        userDebt[u.email] = totalPaid - userExpenses[u.email]
-      })
+        const paid = trip.transactions.filter(tx => tx.email === u.email).reduce((s, tx) => s + tx.cost, 0);
+        net[u.email] = paid - spent[u.email];
+      });
 
-      const result = []
+      const result = [];
       trip.users.forEach(borrower => {
         trip.users.forEach(lender => {
-          if (borrower.email !== lender.email) {
-            const amountOwed = Math.min(userDebt[borrower.email], -userDebt[lender.email])
-            if (amountOwed > 0.005) {
-              result.push({ from_user: borrower, to_user: lender, amount: amountOwed })
-              userDebt[borrower.email] -= amountOwed
-              userDebt[lender.email] += amountOwed
-            }
+          if (borrower.email === lender.email) return;
+          const amt = Math.min(net[borrower.email], -net[lender.email]);
+          if (amt > 0.005) {
+            result.push({ from_user: borrower, to_user: lender, amount: amt });
+            net[borrower.email] -= amt;
+            net[lender.email]  += amt;
           }
-        })
-      })
-      return result
-    })
+        });
+      });
+      return result;
+    });
 
     const perPersonCost = computed(() => {
-      if (!currentTrip.value || !transactionForm.cost) return '0.00'
-      return (parseFloat(transactionForm.cost) / currentTrip.value.users.length).toFixed(2)
-    })
+      if (!currentTrip.value || !transactionForm.cost) return '0.00';
+      return (parseFloat(transactionForm.cost) / currentTrip.value.users.length).toFixed(2);
+    });
 
     const addTransaction = () => {
-      const trip = currentTrip.value
-      if (!trip) return
-      const cost = parseFloat(transactionForm.cost)
-      const perPerson = parseFloat((cost / trip.users.length).toFixed(2))
-      const details = trip.users.map(u => ({ email: u.email, cost: perPerson }))
-
+      const trip = currentTrip.value;
+      if (!trip) return;
+      const cost = parseFloat(transactionForm.cost);
+      const per  = parseFloat((cost / trip.users.length).toFixed(2));
       trip.transactions.push({
         id: Date.now(),
-        title: transactionForm.title.trim(),
-        email: transactionForm.email,
+        title:  transactionForm.title.trim(),
+        email:  transactionForm.email,
         cost,
         transaction_date: new Date().toISOString(),
-        details
-      })
-      saveTrips()
-      transactionForm.email = ''
-      transactionForm.title = ''
-      transactionForm.cost = ''
-      showAddTransaction.value = false
-    }
+        details: trip.users.map(u => ({ email: u.email, cost: per }))
+      });
+      saveTrips();
+      Object.assign(transactionForm, { email: '', title: '', cost: '' });
+      showAddTransaction.value = false;
+    };
 
-    const confirmDeleteTransaction = (txId) => {
-      if (!confirm('Delete this transaction?')) return
-      const trip = currentTrip.value
-      if (!trip) return
-      trip.transactions = trip.transactions.filter(tx => tx.id !== txId)
-      saveTrips()
-    }
+    const confirmDeleteTransaction = txId => {
+      if (!confirm('Delete this transaction?')) return;
+      const trip = currentTrip.value;
+      if (trip) { trip.transactions = trip.transactions.filter(tx => tx.id !== txId); saveTrips(); }
+    };
 
     const settleTrip = () => {
-      if (!confirm('Mark this trip as settled? No more transactions can be added after this.')) return
-      currentTrip.value.is_resolved = true
-      saveTrips()
-    }
+      if (!confirm('Mark as settled? No more transactions can be added.')) return;
+      currentTrip.value.is_resolved = true;
+      saveTrips();
+    };
 
     return {
       view, currentUser, setupForm, tripForm, transactionForm,
-      showAddTrip, showAddTransaction,
+      showAddTrip, showAddTransaction, showInstallBanner,
       myTrips, currentTrip, myPaid, mappedDebt, perPersonCost,
-      tripTotal, completeSetup, logout,
+      tripTotal, completeSetup, logout, dismissInstallBanner,
       addParticipant, removeParticipant, createTrip, confirmDeleteTrip, openTrip,
       addTransaction, confirmDeleteTransaction, settleTrip
-    }
+    };
   }
-}).mount('#app')
+}).mount('#app');
 </script>
-
 </body>
 </html>

--- a/urunan.html
+++ b/urunan.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Urunan – Split Your Bills</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    [v-cloak] { display: none; }
+    input, select, button { -webkit-tap-highlight-color: transparent; }
+    body { -webkit-font-smoothing: antialiased; }
+  </style>
+</head>
+<body class="bg-gray-50 min-h-screen text-gray-800">
+
+<div id="app" v-cloak class="max-w-lg mx-auto px-4 pb-10 min-h-screen flex flex-col">
+
+  <!-- ── SETUP VIEW ───────────────────────────────────────────────── -->
+  <div v-if="view === 'setup'" class="flex-1 flex flex-col justify-center py-12">
+    <div class="text-center mb-8">
+      <div class="text-5xl mb-3">🧾</div>
+      <h1 class="text-3xl font-bold text-teal-600">Urunan</h1>
+      <p class="text-gray-400 mt-1">Split bills with friends &amp; family</p>
+    </div>
+    <form @submit.prevent="completeSetup" class="space-y-3">
+      <input v-model="setupForm.name" type="text" required placeholder="Your name"
+        class="w-full p-3 border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-teal-400 text-base">
+      <input v-model="setupForm.email" type="email" required placeholder="Your email"
+        class="w-full p-3 border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-teal-400 text-base">
+      <button type="submit"
+        class="w-full p-3 bg-teal-500 hover:bg-teal-600 text-white rounded-xl font-semibold text-base transition-colors">
+        Get Started
+      </button>
+    </form>
+    <p class="text-center text-xs text-gray-400 mt-4">All data is saved locally on this device.</p>
+  </div>
+
+  <!-- ── TRIP LIST VIEW ────────────────────────────────────────────── -->
+  <div v-else-if="view === 'trips'" class="flex-1 flex flex-col">
+    <!-- Header -->
+    <div class="flex items-center justify-between py-4 border-b border-gray-200 mb-4">
+      <div>
+        <span class="font-semibold">🏕️ {{ currentUser.name }}</span>
+        <span class="text-xs text-gray-400 ml-2">{{ currentUser.email }}</span>
+      </div>
+      <button @click="logout"
+        class="text-sm px-3 py-1 bg-red-50 text-red-500 rounded-full border border-red-100">
+        Logout
+      </button>
+    </div>
+
+    <h2 class="text-lg font-semibold mb-3">Your Trips</h2>
+
+    <!-- Create Trip Toggle -->
+    <button @click="showAddTrip = !showAddTrip"
+      class="w-full p-3 mb-3 border border-dashed border-gray-300 rounded-xl bg-white text-gray-500 text-sm text-center">
+      {{ showAddTrip ? '✕ Cancel' : '+ Create New Trip' }}
+    </button>
+
+    <!-- Create Trip Form -->
+    <div v-if="showAddTrip" class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
+      <form @submit.prevent="createTrip" class="space-y-2">
+        <input v-model="tripForm.title" type="text" required placeholder="Trip name (e.g. Bali 2024)"
+          class="w-full p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
+        <input v-model="tripForm.text" type="text" placeholder="Description (optional)"
+          class="w-full p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
+
+        <p class="text-xs text-gray-500 pt-1 font-medium">Participants</p>
+        <div class="flex gap-2">
+          <input v-model="tripForm.participantInput" type="email" placeholder="friend@email.com"
+            class="flex-1 p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400"
+            @keydown.enter.prevent="addParticipant">
+          <button type="button" @click="addParticipant"
+            class="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg text-sm text-gray-700 transition-colors">
+            Add
+          </button>
+        </div>
+
+        <div v-if="tripForm.participants.length" class="flex flex-wrap gap-2">
+          <span v-for="p in tripForm.participants" :key="p.email"
+            class="flex items-center gap-1 px-2.5 py-1 bg-teal-50 text-teal-700 rounded-full text-xs border border-teal-100">
+            {{ p.email }}
+            <button type="button" @click="removeParticipant(p.email)"
+              class="ml-0.5 text-teal-400 hover:text-red-400 font-bold leading-none">×</button>
+          </span>
+        </div>
+        <p class="text-xs text-gray-400">You ({{ currentUser.email }}) are included automatically.</p>
+
+        <button type="submit"
+          class="w-full p-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium transition-colors mt-1">
+          Save Trip
+        </button>
+      </form>
+    </div>
+
+    <!-- Trip Cards -->
+    <div v-if="myTrips.length === 0 && !showAddTrip"
+      class="flex-1 flex flex-col items-center justify-center text-gray-400 py-16">
+      <div class="text-4xl mb-3">🧳</div>
+      <p class="text-sm">No trips yet. Create one above!</p>
+    </div>
+
+    <div v-for="trip in myTrips" :key="trip.id"
+      class="bg-white border border-gray-200 rounded-xl p-4 mb-3 shadow-sm">
+      <div class="flex items-start gap-3">
+        <div @click="openTrip(trip.id)" class="flex-1 cursor-pointer min-w-0">
+          <div class="flex items-center gap-2">
+            <h3 class="font-semibold text-gray-800 truncate">{{ trip.title }}</h3>
+            <span v-if="trip.is_resolved"
+              class="shrink-0 text-xs px-2 py-0.5 bg-green-100 text-green-600 rounded-full">Settled</span>
+          </div>
+          <p v-if="trip.text" class="text-sm text-gray-400 mt-0.5 truncate">{{ trip.text }}</p>
+          <p class="text-xs text-gray-400 mt-1.5">
+            👥 {{ trip.users.length }} · 💳 {{ trip.transactions.length }} transactions
+            · Total €{{ tripTotal(trip).toFixed(2) }}
+          </p>
+        </div>
+        <button @click="confirmDeleteTrip(trip.id)"
+          class="shrink-0 text-gray-300 hover:text-red-400 transition-colors p-1 text-lg leading-none">
+          🗑
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── TRIP DETAIL VIEW ──────────────────────────────────────────── -->
+  <div v-else-if="view === 'trip-detail' && currentTrip" class="flex-1 flex flex-col">
+    <!-- Back bar -->
+    <div class="flex items-center gap-3 py-4 border-b border-gray-200 mb-4">
+      <button @click="view = 'trips'" class="text-teal-500 font-medium">← Back</button>
+      <h2 class="font-semibold flex-1 truncate">{{ currentTrip.title }}</h2>
+      <span v-if="currentTrip.is_resolved"
+        class="shrink-0 text-xs px-2 py-1 bg-green-100 text-green-600 rounded-full">Settled</span>
+    </div>
+
+    <!-- Debt Summary Card -->
+    <div class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
+      <h3 class="font-semibold mb-2 text-base">💰 Summary</h3>
+      <p class="text-sm text-gray-600">
+        You paid: <span class="font-semibold text-gray-800">€{{ myPaid.toFixed(2) }}</span>
+      </p>
+
+      <div v-if="mappedDebt.length === 0" class="text-sm text-gray-400 mt-2">
+        {{ currentTrip.transactions.length === 0 ? 'No transactions yet.' : 'All settled up! 🎉' }}
+      </div>
+
+      <div v-for="debt in mappedDebt" :key="debt.from_user.email + '>' + debt.to_user.email"
+        class="mt-1.5 text-sm">
+        <span v-if="debt.from_user.email === currentUser.email" class="text-red-500 font-medium">
+          ↑ You owe {{ debt.to_user.email }}: €{{ debt.amount.toFixed(2) }}
+        </span>
+        <span v-else-if="debt.to_user.email === currentUser.email" class="text-green-600 font-medium">
+          ↓ {{ debt.from_user.email }} owes you: €{{ debt.amount.toFixed(2) }}
+        </span>
+        <span v-else class="text-gray-500">
+          {{ debt.from_user.email }} → {{ debt.to_user.email }}: €{{ debt.amount.toFixed(2) }}
+        </span>
+      </div>
+
+      <button v-if="!currentTrip.is_resolved && currentTrip.transactions.length > 0"
+        @click="settleTrip"
+        class="mt-3 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-sm font-medium transition-colors">
+        ✓ Settle Trip
+      </button>
+    </div>
+
+    <!-- Participants -->
+    <div class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
+      <h3 class="font-semibold mb-2 text-sm">👥 Participants ({{ currentTrip.users.length }})</h3>
+      <div class="flex flex-wrap gap-2">
+        <span v-for="u in currentTrip.users" :key="u.email"
+          class="text-xs px-2.5 py-1 bg-gray-100 text-gray-600 rounded-full">
+          {{ u.email }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Transactions Section -->
+    <div v-if="!currentTrip.is_resolved">
+      <div class="flex items-center justify-between mb-2">
+        <h3 class="font-semibold">🥤 Transactions</h3>
+        <span class="text-xs text-gray-400">Total €{{ tripTotal(currentTrip).toFixed(2) }}</span>
+      </div>
+
+      <button @click="showAddTransaction = !showAddTransaction"
+        class="w-full p-3 mb-3 border border-dashed border-gray-300 rounded-xl bg-white text-gray-500 text-sm text-center">
+        {{ showAddTransaction ? '✕ Cancel' : '+ Add Transaction' }}
+      </button>
+
+      <!-- Add Transaction Form -->
+      <div v-if="showAddTransaction" class="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
+        <form @submit.prevent="addTransaction" class="space-y-2">
+          <select v-model="transactionForm.email" required
+            class="w-full p-2.5 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-400">
+            <option value="" disabled>-- Who paid? --</option>
+            <option v-for="u in currentTrip.users" :key="u.email" :value="u.email">
+              {{ u.email }}
+            </option>
+          </select>
+          <input v-model="transactionForm.title" type="text" required placeholder="What was it for?"
+            class="w-full p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
+          <div class="relative">
+            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm pointer-events-none">€</span>
+            <input v-model.number="transactionForm.cost" type="number" min="0.01" step="any" required placeholder="0.00"
+              class="w-full pl-7 p-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-400">
+          </div>
+          <p class="text-xs text-gray-400">Split equally: €{{ perPersonCost }} per person</p>
+          <button type="submit"
+            class="w-full p-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium transition-colors">
+            Add Transaction
+          </button>
+        </form>
+      </div>
+    </div>
+
+    <!-- Transaction List -->
+    <div v-if="currentTrip.is_resolved" class="mb-2">
+      <h3 class="font-semibold mb-2">🥤 Transactions</h3>
+    </div>
+
+    <div v-if="currentTrip.transactions.length === 0" class="text-center text-gray-400 py-8 text-sm">
+      No transactions yet.
+    </div>
+
+    <div v-for="tx in [...currentTrip.transactions].reverse()" :key="tx.id"
+      class="bg-white border border-gray-200 rounded-xl p-3.5 mb-2.5 shadow-sm">
+      <div class="flex items-start gap-2">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center justify-between gap-2">
+            <p class="font-medium text-sm truncate">{{ tx.title }}</p>
+            <span class="shrink-0 font-semibold text-sm text-gray-700">€{{ tx.cost.toFixed(2) }}</span>
+          </div>
+          <p class="text-xs text-gray-400 mt-0.5">Paid by {{ tx.email }}</p>
+          <div class="mt-1.5 flex flex-wrap gap-1">
+            <span v-for="d in tx.details" :key="d.email"
+              class="text-xs px-2 py-0.5 bg-gray-100 rounded-full text-gray-500">
+              {{ d.email.split('@')[0] }}: €{{ d.cost.toFixed(2) }}
+            </span>
+          </div>
+        </div>
+        <button v-if="!currentTrip.is_resolved" @click="confirmDeleteTransaction(tx.id)"
+          class="shrink-0 text-gray-300 hover:text-red-400 transition-colors p-1 text-lg leading-none">
+          🗑
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="pt-8 pb-2 text-center text-xs text-gray-300">
+    Urunan © 2024 · Data stored locally on this device
+  </footer>
+</div>
+
+<script>
+const { createApp, reactive, computed, ref } = Vue;
+
+createApp({
+  setup() {
+    const view = ref('setup')
+    const currentUser = ref(null)
+    const trips = ref([])
+    const currentTripId = ref(null)
+    const showAddTrip = ref(false)
+    const showAddTransaction = ref(false)
+
+    const setupForm = reactive({ name: '', email: '' })
+    const tripForm = reactive({ title: '', text: '', participantInput: '', participants: [] })
+    const transactionForm = reactive({ email: '', title: '', cost: '' })
+
+    // ── localStorage helpers ──────────────────────────────────────
+    const saveTrips = () => {
+      localStorage.setItem('urunan_trips', JSON.stringify(trips.value))
+    }
+
+    // ── Init: restore saved session ───────────────────────────────
+    const savedUser = localStorage.getItem('urunan_user')
+    if (savedUser) {
+      currentUser.value = JSON.parse(savedUser)
+      const savedTrips = localStorage.getItem('urunan_trips')
+      trips.value = savedTrips ? JSON.parse(savedTrips) : []
+      view.value = 'trips'
+    }
+
+    // ── Setup ────────────────────────────────────────────────────
+    const completeSetup = () => {
+      currentUser.value = { name: setupForm.name.trim(), email: setupForm.email.trim().toLowerCase() }
+      localStorage.setItem('urunan_user', JSON.stringify(currentUser.value))
+      view.value = 'trips'
+    }
+
+    const logout = () => {
+      if (!confirm('Log out? Your data will remain saved on this device.')) return
+      currentUser.value = null
+      localStorage.removeItem('urunan_user')
+      setupForm.name = ''
+      setupForm.email = ''
+      view.value = 'setup'
+    }
+
+    // ── Trip List ─────────────────────────────────────────────────
+    const myTrips = computed(() => {
+      if (!currentUser.value) return []
+      return trips.value.filter(t =>
+        t.users.some(u => u.email === currentUser.value.email)
+      )
+    })
+
+    const tripTotal = (trip) =>
+      trip.transactions.reduce((sum, tx) => sum + tx.cost, 0)
+
+    const addParticipant = () => {
+      const email = tripForm.participantInput.trim().toLowerCase()
+      if (!email) return
+      if (email === currentUser.value.email) {
+        tripForm.participantInput = ''
+        return
+      }
+      if (!tripForm.participants.find(p => p.email === email)) {
+        tripForm.participants.push({ email })
+      }
+      tripForm.participantInput = ''
+    }
+
+    const removeParticipant = (email) => {
+      tripForm.participants = tripForm.participants.filter(p => p.email !== email)
+    }
+
+    const createTrip = () => {
+      const users = [
+        { email: currentUser.value.email },
+        ...tripForm.participants
+      ]
+      trips.value.push({
+        id: Date.now(),
+        title: tripForm.title.trim(),
+        text: tripForm.text.trim(),
+        is_resolved: false,
+        users,
+        transactions: []
+      })
+      saveTrips()
+      tripForm.title = ''
+      tripForm.text = ''
+      tripForm.participantInput = ''
+      tripForm.participants = []
+      showAddTrip.value = false
+    }
+
+    const confirmDeleteTrip = (tripId) => {
+      if (!confirm('Delete this trip and all its transactions?')) return
+      trips.value = trips.value.filter(t => t.id !== tripId)
+      saveTrips()
+    }
+
+    const openTrip = (tripId) => {
+      currentTripId.value = tripId
+      showAddTransaction.value = false
+      transactionForm.email = ''
+      transactionForm.title = ''
+      transactionForm.cost = ''
+      view.value = 'trip-detail'
+    }
+
+    // ── Trip Detail ───────────────────────────────────────────────
+    const currentTrip = computed(() =>
+      trips.value.find(t => t.id === currentTripId.value) || null
+    )
+
+    const myPaid = computed(() => {
+      if (!currentTrip.value || !currentUser.value) return 0
+      return currentTrip.value.transactions
+        .filter(tx => tx.email === currentUser.value.email)
+        .reduce((sum, tx) => sum + tx.cost, 0)
+    })
+
+    // Ported from frontend/src/views/TripDetail.vue (with bug fix on userDebt key)
+    const mappedDebt = computed(() => {
+      if (!currentTrip.value) return []
+      const trip = currentTrip.value
+
+      const userExpenses = {}
+      trip.users.forEach(u => { userExpenses[u.email] = 0 })
+      trip.transactions.forEach(tx => {
+        tx.details.forEach(portion => {
+          userExpenses[portion.email] = (userExpenses[portion.email] || 0) + portion.cost
+        })
+      })
+
+      const userDebt = {}
+      trip.users.forEach(u => {
+        const totalPaid = trip.transactions
+          .filter(tx => tx.email === u.email)
+          .reduce((sum, tx) => sum + tx.cost, 0)
+        userDebt[u.email] = totalPaid - userExpenses[u.email]
+      })
+
+      const result = []
+      trip.users.forEach(borrower => {
+        trip.users.forEach(lender => {
+          if (borrower.email !== lender.email) {
+            const amountOwed = Math.min(userDebt[borrower.email], -userDebt[lender.email])
+            if (amountOwed > 0.005) {
+              result.push({ from_user: borrower, to_user: lender, amount: amountOwed })
+              userDebt[borrower.email] -= amountOwed
+              userDebt[lender.email] += amountOwed
+            }
+          }
+        })
+      })
+      return result
+    })
+
+    const perPersonCost = computed(() => {
+      if (!currentTrip.value || !transactionForm.cost) return '0.00'
+      return (parseFloat(transactionForm.cost) / currentTrip.value.users.length).toFixed(2)
+    })
+
+    const addTransaction = () => {
+      const trip = currentTrip.value
+      if (!trip) return
+      const cost = parseFloat(transactionForm.cost)
+      const perPerson = parseFloat((cost / trip.users.length).toFixed(2))
+      const details = trip.users.map(u => ({ email: u.email, cost: perPerson }))
+
+      trip.transactions.push({
+        id: Date.now(),
+        title: transactionForm.title.trim(),
+        email: transactionForm.email,
+        cost,
+        transaction_date: new Date().toISOString(),
+        details
+      })
+      saveTrips()
+      transactionForm.email = ''
+      transactionForm.title = ''
+      transactionForm.cost = ''
+      showAddTransaction.value = false
+    }
+
+    const confirmDeleteTransaction = (txId) => {
+      if (!confirm('Delete this transaction?')) return
+      const trip = currentTrip.value
+      if (!trip) return
+      trip.transactions = trip.transactions.filter(tx => tx.id !== txId)
+      saveTrips()
+    }
+
+    const settleTrip = () => {
+      if (!confirm('Mark this trip as settled? No more transactions can be added after this.')) return
+      currentTrip.value.is_resolved = true
+      saveTrips()
+    }
+
+    return {
+      view, currentUser, setupForm, tripForm, transactionForm,
+      showAddTrip, showAddTransaction,
+      myTrips, currentTrip, myPaid, mappedDebt, perPersonCost,
+      tripTotal, completeSetup, logout,
+      addParticipant, removeParticipant, createTrip, confirmDeleteTrip, openTrip,
+      addTransaction, confirmDeleteTransaction, settleTrip
+    }
+  }
+}).mount('#app')
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Converts all Urunan features into a single self-contained `urunan.html` that runs entirely in the browser — no server, no build step, no install — and deploys it to GitHub Pages.

### `urunan.html` (188 KB, fully offline-capable)
- All core features ported: trip creation with participants, transactions with equal split, debt summary ("who owes whom"), trip settlement, deletion
- Debt calculation algorithm ported from `frontend/src/views/TripDetail.vue` (with a bug fix: the original mutated `userDebt[borrower]` instead of `userDebt[borrower.email]`)
- Vue 3 production build inlined (no CDN, works with no internet)
- Tailwind replaced with hand-written component CSS
- Auth0 replaced with a local name/email setup screen; FastAPI + database replaced with `localStorage`
- PWA meta tags + embedded base64 app icon, so "Add to Home Screen" in Safari/Chrome gives a tappable full-screen app icon
- First-run banner guiding users through Add to Home Screen

### GitHub Pages deployment (`.github/workflows/github-pages.yml`)
- Triggers on pushes to `main` touching `urunan.html` (plus manual `workflow_dispatch`)
- Auto-enables Pages via `actions/configure-pages` — no repository settings changes needed
- Publishes the file as `index.html` at **https://rezpaditya.github.io/Urunan/**

**Merging this PR will trigger the first deployment automatically.**

### Notes
- Data lives in each device's `localStorage` — each visitor gets a private local copy; nothing syncs between devices
- The existing Vue/FastAPI app and its Docker deployment are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DV6jcVXtaXEABZAVkNwpb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DV6jcVXtaXEABZAVkNwpb8)_