### PR TITLE
Auto-sync all joined trips on app startup

### DIFF
--- a/urunan.html
+++ b/urunan.html
@@ -3384,6 +3384,15 @@ createApp({
       syncDebounce[String(tripId)] = setTimeout(() => syncNow(tripId), 1500);
     };
 
+    // Pull the latest for every synced trip on launch, so a cold start
+    // (e.g. an installed home-screen app that already joined sync) shows
+    // fresh data without having to open each trip first. Fire-and-forget;
+    // each syncNow is re-entrancy guarded and skips no-op pushes.
+    const syncAllOnStartup = () => {
+      if (!syncAvailable) return;
+      for (const tripId of Object.keys(syncMeta)) syncNow(tripId);
+    };
+
     const syncBaseHref = () => location.protocol === 'file:'
       ? location.href.split('#')[0]
       : location.origin + location.pathname;
@@ -3503,6 +3512,9 @@ createApp({
     // Also import when a share link lands in an already-open app
     // (same-document navigation fires hashchange, not a page load)
     window.addEventListener('hashchange', handleIncomingShare);
+
+    // Refresh all already-joined synced trips on launch.
+    syncAllOnStartup();
 
     return {
       view, currentUser, setupForm, tripForm, transactionForm,


### PR DESCRIPTION
## What & why

Sync previously only ran when you **opened a trip**, when the app **regained focus** (and only for the currently open trip), or **after a local edit**. Nothing synced at launch.

The consequence: on a cold start — e.g. an installed home-screen PWA that had already joined sync — the trip list showed whatever was in `localStorage` and never pulled the latest until you tapped into each trip individually. This is the "data isn't showing when I open the home-screen app" symptom.

## Change

Adds `syncAllOnStartup()`, invoked once during init (right after `handleIncomingShare()`), which iterates over every trip in `syncMeta` and calls `syncNow` to pull the latest.

- No-op when the relay is disabled (`SYNC_BASE_URL` empty) or when no trips have sync enabled.
- Fire-and-forget; each `syncNow` is already re-entrancy guarded and skips no-op pushes via the fingerprint check.

> Note: this refreshes trips that have **already joined** sync. For a freshly installed PWA with separate/empty storage, the user still needs to open the `#sync=<room>.<key>` link inside the installed app once to bootstrap the room credentials — after that, startup sync keeps it fresh.

## Testing

Verified by loading `urunan.html` in Chromium (Playwright) with mocked relay routes, each in an isolated browser context:

| Case | Expectation | Result |
|---|---|---|
| User with a joined synced trip | startup sync fires (relay GET) | ✅ 1 relay hit |
| User with trips but sync not enabled | no relay call (regression guard) | ✅ 0 hits |
| Fresh/empty install | no crash, no relay call | ✅ 0 hits, no errors |

App renders the trips view correctly in all cases; no page/console errors (aside from the mocked 404 responses). `node --check` passes on the extracted app script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5RKdMX7a9eWzSNXferg3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5RKdMX7a9eWzSNXferg3Q)_