### PR TITLE
Add agent.md docs to every directory

### DIFF
--- a/.github/agent.md
+++ b/.github/agent.md
@@ -1,0 +1,14 @@
+# agent.md — .github
+
+GitHub configuration for the repository.
+
+## Contents
+
+- `workflows/` — GitHub Actions workflows. Currently just the GitHub Pages
+  publisher for `urunan.html`.
+
+## Notes
+
+- The only active automation here publishes the app to GitHub Pages. See
+  `workflows/agent.md` for details.
+- Keep automation minimal — the app has no build step, so CI stays lightweight.

--- a/.github/workflows/agent.md
+++ b/.github/workflows/agent.md
@@ -1,0 +1,20 @@
+# agent.md — .github/workflows
+
+GitHub Actions workflows.
+
+## Files
+
+- `github-pages.yml` — Publishes the app to GitHub Pages. On a push to `main`
+  that changes `urunan.html` (or manual `workflow_dispatch`), it copies
+  `urunan.html` into the `gh-pages` branch as `index.html` and pushes. GitHub
+  Pages then serves the site from `gh-pages`, and its built-in "pages build and
+  deployment" workflow publishes the push.
+
+## Notes
+
+- Pages deploys **only** from the `gh-pages` branch (enforced by the
+  `github-pages` environment), which is why this workflow copies the file
+  across rather than deploying directly from `main`.
+- Don't hand-edit `gh-pages`; let this workflow keep it in sync.
+- The workflow is a no-op commit when the file is unchanged (`git diff
+  --cached --quiet` guard), so re-runs are safe.

--- a/.vscode/agent.md
+++ b/.vscode/agent.md
@@ -1,0 +1,16 @@
+# agent.md — .vscode
+
+Editor (VS Code) settings for local development.
+
+## Files
+
+- `launch.json` — Debug launch configurations:
+  - **Python Debugger: FastAPI** — runs `backend.main:app` under `uvicorn`.
+  - **Client Vue3** — runs `npm run dev` in the `frontend/` directory.
+
+## Notes
+
+- These configs target the **archived** FastAPI backend and Vue/Vite frontend,
+  not the current single-file `urunan.html` app. They're kept for anyone
+  reviving the archived stack under `archived/`.
+- The current app needs no launch config — just open `urunan.html` in a browser.

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,45 @@
+# agent.md — repository root
+
+Guidance for AI agents working in the Urunan repository.
+
+## What this project is
+
+Urunan is a bill-splitting app for trips and group activities. The **entire
+current app is a single self-contained file**, [`urunan.html`](urunan.html):
+Vue 3 and a QR-code generator are inlined, styling is hand-written CSS, and
+all data lives in the browser's `localStorage`. There is no server, no build
+step, and no dependencies for the app itself.
+
+Live app: https://rezpaditya.github.io/Urunan/
+
+## Layout
+
+| Path             | What it is                                                       |
+| ---------------- | --------------------------------------------------------------- |
+| `urunan.html`    | The whole app — the primary artifact of this repo.              |
+| `sync-server/`   | Optional stateless relay for cross-device sync (Python stdlib). |
+| `.github/`       | GitHub Actions — publishes `urunan.html` to GitHub Pages.       |
+| `.vscode/`       | Editor launch configs (mostly for the archived stack).          |
+| `archived/`      | The old FastAPI + Vue/Vite client. **Retired — do not extend.** |
+| `README.md`      | User- and contributor-facing overview.                          |
+
+## Working conventions
+
+- **`urunan.html` is the app.** Feature work, bug fixes, and styling changes
+  go here. Keep it self-contained: no external CDN links, no build tooling,
+  no added runtime dependencies. Everything ships inlined.
+- **Data lives in `localStorage`** per device. There is no backend database;
+  don't introduce one.
+- **Sync is optional and off by default.** It only activates when the app is
+  pointed at a relay via `SYNC_BASE_URL` near the top of `urunan.html`. The
+  relay never sees plaintext — payloads are gzipped and AES-GCM encrypted in
+  the browser first. Keep that property intact.
+- **`archived/` is frozen.** It documents the previous architecture; treat it
+  as read-only history unless explicitly asked to revive it.
+- Publishing to GitHub Pages happens automatically when `urunan.html` changes
+  on `main` (see `.github/workflows/`). Don't hand-edit the `gh-pages` branch.
+
+## Verifying changes
+
+Open `urunan.html` directly in a browser (a `file://` URL works) and exercise
+the affected flow. There is no test suite or build to run for the main app.

--- a/archived/agent.md
+++ b/archived/agent.md
@@ -1,0 +1,22 @@
+# agent.md — archived
+
+**Retired code. Frozen history — do not extend.**
+
+This directory holds the previous architecture of Urunan, before the app was
+rewritten as the single self-contained `urunan.html` at the repo root. It is
+kept for reference only.
+
+## Contents
+
+- `backend/` — the old FastAPI + SQLAlchemy + SQLite server.
+- `frontend/` — the old Vue 3 + Vite + Tailwind + Auth0 single-page client.
+- `docker-deploy.yml` — the old CI/CD workflow that built and pushed Docker
+  images for the backend and frontend to GHCR and deployed over SSH.
+
+## For agents
+
+- **Do not add features here.** The live app is `urunan.html` at the repo root.
+- Treat everything under `archived/` as read-only unless the user explicitly
+  asks to revive or migrate from this stack.
+- This code depends on services no longer in use (Auth0, a hosted DB, GHCR,
+  an SSH deploy target) and is not wired into any current workflow.

--- a/archived/backend/agent.md
+++ b/archived/backend/agent.md
@@ -1,0 +1,28 @@
+# agent.md — archived/backend
+
+**Retired.** The old FastAPI backend for Urunan. Not used by the current app
+(`urunan.html`). Kept for reference only — see `../agent.md`.
+
+## What it was
+
+A FastAPI service backed by SQLAlchemy over SQLite. It exposed REST endpoints
+for trips, transactions, and users.
+
+## Layout
+
+- `main.py` — App entrypoint. Creates FastAPI, adds permissive CORS, seeds the
+  user table on create, and mounts the routers.
+- `dependency.py` — `get_db` dependency yielding a SQLAlchemy session.
+- `db/` — SQLAlchemy models, schemas (Pydantic), CRUD helpers, engine/session.
+- `router/` — API routers: `trips`, `transactions`, `users`.
+- `Dockerfile`, `Pipfile`, `Pipfile.lock` — container build and deps.
+- `cert.pem`, `key.pem` — TLS material for the old deployment.
+- `__ini__.py` — (note the typo) an old package marker.
+
+## Notes for agents
+
+- Runtime config came from env: `DB_FILE_PATH` sets the SQLite path (see
+  `db/database.py`).
+- CORS was wide open (`allow_origins=["*"]`) — a known rough edge of this
+  retired stack, not a pattern to copy.
+- Do not extend this. New work belongs in `urunan.html`.

--- a/archived/backend/db/agent.md
+++ b/archived/backend/db/agent.md
@@ -1,0 +1,19 @@
+# agent.md — archived/backend/db
+
+**Retired.** Data layer for the old FastAPI backend. See `../../agent.md`.
+
+## Files
+
+- `database.py` — SQLAlchemy engine/session setup. Builds the SQLite URL from
+  the `DB_FILE_PATH` env var, defines `SessionLocal` and the declarative
+  `Base`, and seeds initial users via an `after_create` hook.
+- `models.py` — ORM models: `User`, `Trip`, `Transaction`, `TransactionDetail`,
+  and the `trip_user` association table (many-to-many trips↔users).
+- `schemas.py` — Pydantic request/response schemas.
+- `crud.py` — Generic DB helpers (`get`, `get_by_id`, `create`, …) that take a
+  DAO/model class so they work across entities.
+
+## Notes
+
+- SQLite with `check_same_thread=False`; single-file DB.
+- Frozen — do not modify. Current app uses browser `localStorage`, not a DB.

--- a/archived/backend/router/agent.md
+++ b/archived/backend/router/agent.md
@@ -1,0 +1,19 @@
+# agent.md — archived/backend/router
+
+**Retired.** FastAPI API routers for the old backend. See `../../agent.md`.
+
+## Files
+
+- `trips.py` — `/trips` endpoints (list, get by id, create, …).
+- `transactions.py` — `/transactions` endpoints.
+- `users.py` — `/users` endpoints.
+
+## Pattern (for reference)
+
+Each module defines an `APIRouter` with a `prefix` and `tags`, depends on
+`get_db` from `../dependency.py`, and delegates persistence to the generic
+helpers in `../db/crud.py` using the models from `../db/models.py`.
+
+## Notes
+
+- Frozen — do not extend. Mounted in `../main.py` via `include_router`.

--- a/archived/frontend/agent.md
+++ b/archived/frontend/agent.md
@@ -1,0 +1,29 @@
+# agent.md — archived/frontend
+
+**Retired.** The old Vue 3 single-page client for Urunan. Not used by the
+current app (`urunan.html`). Kept for reference only — see `../agent.md`.
+
+## What it was
+
+A Vue 3 (`<script setup>` SFCs) app built with Vite, styled with Tailwind CSS,
+using Pinia for state, Vue Router for routing, `vue-multiselect` for inputs,
+and Auth0 (`@auth0/auth0-vue`) for authentication. It talked to the FastAPI
+backend under `../backend`.
+
+## Layout
+
+- `src/` — application source (see `src/agent.md`).
+- `public/` — static assets served as-is.
+- `index.html` — Vite HTML entry.
+- `package.json` / `package-lock.json` — deps and scripts (`dev`, `build`,
+  `preview`).
+- `vite.config.js`, `postcss.config.js`, `tailwind.config.js` — build/styling.
+- `.env` — environment config (Auth0 domain/client id, API base, etc.).
+- `Dockerfile` — container build for the old deployment.
+- `.vscode/` — recommended extensions.
+
+## Notes for agents
+
+- Frozen — do not extend. New work belongs in the root `urunan.html`.
+- If ever run for reference: `npm install` then `npm run dev`. Depends on Auth0
+  and the backend, which are no longer operated.

--- a/archived/frontend/public/agent.md
+++ b/archived/frontend/public/agent.md
@@ -1,0 +1,12 @@
+# agent.md — archived/frontend/public
+
+**Retired.** Static assets for the old Vue frontend. See `../agent.md`.
+
+## Contents
+
+- `vite.svg` — default Vite logo asset.
+
+## Notes
+
+- Files here were served as-is from the site root by Vite (no processing).
+- Frozen — reference only.

--- a/archived/frontend/src/agent.md
+++ b/archived/frontend/src/agent.md
@@ -1,0 +1,21 @@
+# agent.md — archived/frontend/src
+
+**Retired.** Source of the old Vue 3 client. See `../agent.md`.
+
+## Layout
+
+- `main.js` — App bootstrap: creates the Vue app, installs Pinia, the router,
+  and the Auth0 plugin, then mounts.
+- `App.vue` — Root component.
+- `router/` — Vue Router config (hash history, route guards via Auth0).
+- `stores/` — Pinia stores (e.g. `user`).
+- `views/` — Route-level pages (Home, Trip, TripDetail, Transaction,
+  TransactionDetail).
+- `components/` — Reusable UI pieces (`TripItem`, `TransactionItem`).
+- `assets/` — Bundled assets imported by components.
+- `index.css` / `style.css` — global styles (Tailwind layers + custom CSS).
+
+## Notes
+
+- Vue 3 `<script setup>` SFC style throughout.
+- Frozen — do not extend. New work belongs in the root `urunan.html`.

--- a/archived/frontend/src/assets/agent.md
+++ b/archived/frontend/src/assets/agent.md
@@ -1,0 +1,13 @@
+# agent.md — archived/frontend/src/assets
+
+**Retired.** Bundled assets for the old Vue client. See `../agent.md`.
+
+## Contents
+
+- `vue.svg` — Vue logo, imported by components (processed by Vite at build).
+
+## Notes
+
+- Unlike `public/`, assets here are imported in code and go through the Vite
+  build pipeline.
+- Frozen — reference only.

--- a/archived/frontend/src/components/agent.md
+++ b/archived/frontend/src/components/agent.md
@@ -1,0 +1,13 @@
+# agent.md — archived/frontend/src/components
+
+**Retired.** Reusable Vue components for the old client. See `../agent.md`.
+
+## Files
+
+- `TripItem.vue` — Renders a single trip row/card in list views.
+- `TransactionItem.vue` — Renders a single transaction row/card.
+
+## Notes
+
+- Vue 3 `<script setup>` SFCs, consumed by the pages in `../views/`.
+- Frozen — reference only.

--- a/archived/frontend/src/router/agent.md
+++ b/archived/frontend/src/router/agent.md
@@ -1,0 +1,15 @@
+# agent.md — archived/frontend/src/router
+
+**Retired.** Vue Router config for the old client. See `../agent.md`.
+
+## Files
+
+- `index.js` — Defines the router using `createWebHashHistory` and maps routes
+  to the pages in `../views/` (home, trip, trip/:id, transaction,
+  transaction/:id). Protected routes use Auth0's `authGuard` via `beforeEnter`.
+
+## Notes
+
+- Hash history is used so the SPA works on static hosting without server
+  rewrites.
+- Frozen — reference only.

--- a/archived/frontend/src/stores/agent.md
+++ b/archived/frontend/src/stores/agent.md
@@ -1,0 +1,12 @@
+# agent.md — archived/frontend/src/stores
+
+**Retired.** Pinia stores for the old Vue client. See `../agent.md`.
+
+## Files
+
+- `user.js` — `useUserStore`, holding the authenticated user's state.
+
+## Notes
+
+- Pinia is installed in `../main.js`.
+- Frozen — reference only.

--- a/archived/frontend/src/views/agent.md
+++ b/archived/frontend/src/views/agent.md
@@ -1,0 +1,16 @@
+# agent.md — archived/frontend/src/views
+
+**Retired.** Route-level pages for the old Vue client. See `../agent.md`.
+
+## Files
+
+- `Home.vue` — Landing page; handles Auth0 login and redirects.
+- `Trip.vue` — Trip list / create.
+- `TripDetail.vue` — Single trip, its participants and transactions.
+- `Transaction.vue` — Transaction list / create.
+- `TransactionDetail.vue` — Single transaction with per-person split.
+
+## Notes
+
+- Wired to routes in `../router/index.js`; some routes are Auth0-guarded.
+- Frozen — reference only.

--- a/sync-server/agent.md
+++ b/sync-server/agent.md
@@ -1,0 +1,40 @@
+# agent.md — sync-server
+
+The optional cross-device sync relay for Urunan.
+
+## What it is
+
+A tiny **stateless** rendezvous server that lets the app sync a trip between
+devices. It is entirely optional — Urunan works fully offline without it, and
+sync is off unless the app is pointed at a relay via `SYNC_BASE_URL`.
+
+## Files
+
+- `server.py` — The whole server. Python **standard library only**, one file.
+  API:
+  - `PUT /room/<id>` — store a payload for a room → `204`
+  - `GET /room/<id>` — fetch the current payload → `200` | `404`
+  - `GET /` — health check → `200`
+  - `OPTIONS *` — CORS preflight → `204`
+- `requirements.txt` — Dependencies (none needed at runtime; stdlib only).
+- `Procfile` — Process definition for platforms like Heroku/Railway.
+- `README.md` — Deploy steps and a curl-based smoke test.
+
+## Design invariants — keep these true
+
+- **Stores nothing durably.** Room payloads live only in memory and only for
+  `TTL_SECONDS` (300s), then are evicted. A restart wipes everything. The
+  devices' `localStorage` is the sole home of the data.
+- **Can't read the data.** The client gzips and AES-GCM encrypts each payload
+  before sending; the key never leaves the share link / the devices, so the
+  relay only ever holds ciphertext. Never add code that would inspect,
+  decrypt, log, or persist payload contents.
+- **No dependencies.** Keep it standard-library-only and single-file.
+- Room ids are validated against `ROOM_ID_RE` (22-char base64url) and bodies
+  are capped at `MAX_BODY_BYTES`. Preserve these guards.
+
+## Run locally
+
+```bash
+PORT=8080 python server.py
+```


### PR DESCRIPTION
Add per-directory agent.md guidance describing what each directory is,
its key files, and conventions for agents. Flags the single-file
urunan.html as the live app, documents the sync-server invariants, and
marks the archived FastAPI/Vue stack as frozen.