### PR TITLE
Add Playwright smoke tests for mandatory features

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,48 @@
+name: Smoke tests
+
+# Runs the Playwright smoke tests in tests/ against urunan.html on every
+# push and PR that touches the app or the tests themselves.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "urunan.html"
+      - "tests/**"
+      - ".github/workflows/smoke-tests.yml"
+  pull_request:
+    paths:
+      - "urunan.html"
+      - "tests/**"
+      - ".github/workflows/smoke-tests.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: npm test
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/playwright-report/
+          retention-days: 7

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# Smoke tests
+
+End-to-end smoke tests for [`urunan.html`](../urunan.html). They drive the app
+exactly the way it ships — a single self-contained file loaded over a `file://`
+URL, no server, no build step — using [Playwright](https://playwright.dev) and
+Chromium. One spec covers each mandatory feature; each test is a thin
+happy-path check that the feature is wired up and works, not an exhaustive
+unit suite.
+
+| Spec                       | Mandatory feature it smoke-tests                                        |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `01-user-setup.spec.js`    | One-time user setup and `localStorage` persistence across reloads.      |
+| `02-trips.spec.js`         | Creating a trip with multiple participants.                             |
+| `03-transactions.spec.js`  | Transactions with even-by-default and custom splits, validated totals.  |
+| `04-settlement.spec.js`    | The "who owes whom" debt summary and settling a trip (locks it).        |
+| `05-share-link.spec.js`    | Sharing a trip via a link and merging on import without duplicates.     |
+
+Optional live device sync is intentionally **not** covered: it is off by
+default, requires a running relay, and isn't a mandatory feature.
+
+## Running
+
+```bash
+cd tests
+npm install          # installs @playwright/test
+npx playwright install chromium   # first run only, to fetch the browser
+npm test
+```
+
+The tests open `urunan.html` directly from disk, so no local server is needed.

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "urunan-smoke-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "urunan-smoke-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.56.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "urunan-smoke-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright smoke tests for urunan.html — one spec per mandatory feature.",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1"
+  }
+}

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,0 +1,24 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Smoke tests for urunan.html — the whole app is a single self-contained file
+ * loaded over file://, exactly how the README says it runs. No server needed.
+ */
+module.exports = defineConfig({
+  testDir: './smoke',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/smoke/01-user-setup.spec.js
+++ b/tests/smoke/01-user-setup.spec.js
@@ -1,0 +1,32 @@
+// @ts-check
+// Mandatory feature: one-time user setup + local persistence.
+const { test, expect } = require('@playwright/test');
+const { APP_URL, setupUser } = require('./helpers');
+
+test('new user completes setup and lands on the trips screen', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+
+  await expect(page.locator('.topbar-name')).toContainText('Alice');
+  await expect(page.locator('.topbar-email')).toHaveText('alice@example.com');
+  await expect(page.getByRole('button', { name: /Create New Trip/ })).toBeVisible();
+});
+
+test('the logged-in user survives a page reload (localStorage persistence)', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+
+  await page.reload();
+
+  // No setup form on reload — the saved user is restored straight to trips.
+  await expect(page.getByPlaceholder('Your name')).toHaveCount(0);
+  await expect(page.locator('.topbar-name')).toContainText('Alice');
+});
+
+test('email is stored lowercased and normalized', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: '  Alice@Example.COM  ' });
+
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('urunan_user'))
+  );
+  expect(stored.email).toBe('alice@example.com');
+  expect(stored.name).toBe('Alice');
+});

--- a/tests/smoke/02-trips.spec.js
+++ b/tests/smoke/02-trips.spec.js
@@ -1,0 +1,44 @@
+// @ts-check
+// Mandatory feature: trips with multiple participants.
+const { test, expect } = require('@playwright/test');
+const { setupUser, createTrip, openTrip } = require('./helpers');
+
+test('create a trip with multiple participants', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+
+  await createTrip(page, {
+    title: 'Bali 2025',
+    participants: ['bob@example.com', 'carol@example.com'],
+  });
+
+  // The trip appears on the list with the correct participant count
+  // (creator + 2 invited = 3).
+  const card = page.locator('.trip-card', { hasText: 'Bali 2025' });
+  await expect(card).toBeVisible();
+  await expect(card.locator('.trip-card-meta')).toContainText('👥 3');
+});
+
+test('opening a trip shows every participant by name', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, {
+    title: 'Bali 2025',
+    participants: ['bob@example.com', 'carol@example.com'],
+  });
+
+  await openTrip(page, 'Bali 2025');
+
+  const chips = page.locator('.participant-chip');
+  await expect(chips).toHaveCount(3);
+  await expect(chips.filter({ hasText: 'Alice' })).toHaveCount(1);
+  await expect(chips.filter({ hasText: 'Bob' })).toHaveCount(1);
+  await expect(chips.filter({ hasText: 'Carol' })).toHaveCount(1);
+});
+
+test('created trips persist across a reload', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, { title: 'Weekend Trip', participants: ['bob@example.com'] });
+
+  await page.reload();
+
+  await expect(page.locator('.trip-card', { hasText: 'Weekend Trip' })).toBeVisible();
+});

--- a/tests/smoke/03-transactions.spec.js
+++ b/tests/smoke/03-transactions.spec.js
@@ -1,0 +1,102 @@
+// @ts-check
+// Mandatory feature: transactions with payment splits — even by default,
+// adjustable per person, validated against the total.
+const { test, expect } = require('@playwright/test');
+const { setupUser, createTrip, openTrip, addTransaction } = require('./helpers');
+
+async function twoPersonTrip(page) {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, { title: 'Trip', participants: ['bob@example.com'] });
+  await openTrip(page, 'Trip');
+}
+
+test('adding a transaction defaults to an even split', async ({ page }) => {
+  await twoPersonTrip(page);
+
+  // Open the form and enter a cost; the even split should prefill each row.
+  await page.getByRole('button', { name: /Add Transaction/ }).click();
+  const form = page.locator('.card-form form');
+  await form.locator('select').selectOption({ label: 'Alice' });
+  await form.getByPlaceholder('What was it for?').fill('Dinner');
+  await form.getByPlaceholder('0.00').first().fill('10');
+
+  const splitInputs = form.locator('.split-row input');
+  await expect(splitInputs).toHaveCount(2);
+  await expect(splitInputs.nth(0)).toHaveValue('5');
+  await expect(splitInputs.nth(1)).toHaveValue('5');
+
+  await form.getByRole('button', { name: 'Add Transaction' }).click();
+
+  const tx = page.locator('.tx-card', { hasText: 'Dinner' });
+  await expect(tx.locator('.tx-amount')).toHaveText('€10.00');
+  await expect(tx.locator('.tx-payer')).toContainText('Paid by Alice');
+  await expect(tx.locator('.tx-split')).toHaveText([/Alice: €5\.00/, /Bob: €5\.00/]);
+});
+
+test('a custom (uneven) split is saved as entered', async ({ page }) => {
+  await twoPersonTrip(page);
+
+  await addTransaction(page, {
+    payerName: 'Alice',
+    title: 'Taxi',
+    cost: 10,
+    splits: { Alice: 2, Bob: 8 },
+  });
+
+  const tx = page.locator('.tx-card', { hasText: 'Taxi' });
+  await expect(tx.locator('.tx-split')).toHaveText([/Alice: €2\.00/, /Bob: €8\.00/]);
+});
+
+test('an under-allocated split is rejected (validated against the total)', async ({ page }) => {
+  await twoPersonTrip(page);
+
+  await page.getByRole('button', { name: /Add Transaction/ }).click();
+  const form = page.locator('.card-form form');
+  await form.locator('select').selectOption({ label: 'Alice' });
+  await form.getByPlaceholder('What was it for?').fill('Broken split');
+  await form.getByPlaceholder('0.00').first().fill('10');
+
+  // Under-allocate: only €4 of €10 assigned.
+  const splitInputs = form.locator('.split-row input');
+  await splitInputs.nth(0).fill('2');
+  await splitInputs.nth(1).fill('2');
+
+  await expect(form.locator('.field-error')).toContainText('left to allocate');
+  const submit = form.getByRole('button', { name: 'Add Transaction' });
+  await expect(submit).toBeDisabled();
+});
+
+test('an over-allocated split is rejected', async ({ page }) => {
+  await twoPersonTrip(page);
+
+  await page.getByRole('button', { name: /Add Transaction/ }).click();
+  const form = page.locator('.card-form form');
+  await form.locator('select').selectOption({ label: 'Alice' });
+  await form.getByPlaceholder('What was it for?').fill('Too much');
+  await form.getByPlaceholder('0.00').first().fill('10');
+
+  const splitInputs = form.locator('.split-row input');
+  await splitInputs.nth(0).fill('9');
+  await splitInputs.nth(1).fill('9');
+
+  await expect(form.locator('.field-error')).toContainText('Over-allocated');
+  await expect(form.getByRole('button', { name: 'Add Transaction' })).toBeDisabled();
+});
+
+test('"Split evenly" restores an even split after manual edits', async ({ page }) => {
+  await twoPersonTrip(page);
+
+  await page.getByRole('button', { name: /Add Transaction/ }).click();
+  const form = page.locator('.card-form form');
+  await form.locator('select').selectOption({ label: 'Alice' });
+  await form.getByPlaceholder('What was it for?').fill('Groceries');
+  await form.getByPlaceholder('0.00').first().fill('10');
+
+  const splitInputs = form.locator('.split-row input');
+  await splitInputs.nth(0).fill('9');
+  await splitInputs.nth(1).fill('1');
+
+  await form.getByRole('button', { name: /Split evenly/ }).click();
+  await expect(splitInputs.nth(0)).toHaveValue('5');
+  await expect(splitInputs.nth(1)).toHaveValue('5');
+});

--- a/tests/smoke/04-settlement.spec.js
+++ b/tests/smoke/04-settlement.spec.js
@@ -1,0 +1,67 @@
+// @ts-check
+// Mandatory features: automatic debt settlement summary ("who pays whom")
+// and settling a trip to lock further changes.
+const { test, expect } = require('@playwright/test');
+const { setupUser, createTrip, openTrip, addTransaction } = require('./helpers');
+
+test('debt summary shows the minimal "who owes whom"', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, { title: 'Trip', participants: ['bob@example.com'] });
+  await openTrip(page, 'Trip');
+
+  // Alice pays €10 split evenly → Bob owes Alice €5.
+  await addTransaction(page, { payerName: 'Alice', title: 'Dinner', cost: 10 });
+
+  await expect(page.locator('.summary-paid')).toContainText('€10.00');
+  const debt = page.locator('.debt-line');
+  await expect(debt).toContainText('Bob owes you');
+  await expect(debt).toContainText('€5.00');
+});
+
+test('debt summary nets out to a minimal set across three people', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, {
+    title: 'Trip',
+    participants: ['bob@example.com', 'carol@example.com'],
+  });
+  await openTrip(page, 'Trip');
+
+  // Alice pays €30 split evenly three ways → Bob and Carol each owe €10.
+  await addTransaction(page, { payerName: 'Alice', title: 'Hotel', cost: 30 });
+
+  const lines = page.locator('.debt-line');
+  await expect(lines).toHaveCount(2);
+  await expect(lines.filter({ hasText: 'Bob owes you' })).toContainText('€10.00');
+  await expect(lines.filter({ hasText: 'Carol owes you' })).toContainText('€10.00');
+});
+
+test('a fully balanced trip reports "all settled up"', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, { title: 'Trip', participants: ['bob@example.com'] });
+  await openTrip(page, 'Trip');
+
+  // Each pays their own €5 share of their own €5 expense → nobody owes anyone.
+  await addTransaction(page, {
+    payerName: 'Alice', title: 'Alice lunch', cost: 5, splits: { Alice: 5, Bob: 0 },
+  });
+  await addTransaction(page, {
+    payerName: 'Bob', title: 'Bob lunch', cost: 5, splits: { Alice: 0, Bob: 5 },
+  });
+
+  await expect(page.locator('.debt-line')).toContainText('All settled up');
+});
+
+test('settling a trip marks it Settled and blocks new transactions', async ({ page }) => {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, { title: 'Trip', participants: ['bob@example.com'] });
+  await openTrip(page, 'Trip');
+  await addTransaction(page, { payerName: 'Alice', title: 'Dinner', cost: 10 });
+
+  page.on('dialog', (d) => d.accept()); // accept the settle confirmation
+  await page.getByRole('button', { name: /Settle Trip/ }).click();
+
+  await expect(page.locator('.badge-settled')).toBeVisible();
+  // The add-transaction toggle and per-transaction edit/delete actions disappear.
+  await expect(page.getByRole('button', { name: /Add Transaction/ })).toHaveCount(0);
+  await expect(page.locator('.tx-actions')).toHaveCount(0);
+});

--- a/tests/smoke/05-share-link.spec.js
+++ b/tests/smoke/05-share-link.spec.js
@@ -1,0 +1,54 @@
+// @ts-check
+// Mandatory feature: share a trip between devices with a link (no server) —
+// the trip data travels in the URL fragment and merges on import without
+// duplicating anything on repeat imports.
+const { test, expect } = require('@playwright/test');
+const { APP_URL, setupUser, createTrip, openTrip, addTransaction } = require('./helpers');
+
+// Build a share link on device A (Alice), then return it.
+async function makeShareLink(page) {
+  await setupUser(page, { name: 'Alice', email: 'alice@example.com' });
+  await createTrip(page, { title: 'Shared Trip', participants: ['bob@example.com'] });
+  await openTrip(page, 'Shared Trip');
+  await addTransaction(page, { payerName: 'Alice', title: 'Dinner', cost: 10 });
+
+  await page.getByRole('button', { name: /Share/ }).click();
+  // Reveal the one-time link/QR export (device sync is the default primary UI).
+  await page.getByRole('button', { name: /One-time link/ }).click();
+  const shareInput = page.locator('.modal input[readonly]');
+  const url = await shareInput.inputValue();
+  expect(url).toContain('#trip=');
+  return url;
+}
+
+test('a shared link carries a trip that imports on another device', async ({ page }) => {
+  const shareUrl = await makeShareLink(page);
+
+  // Simulate a second device: Bob, fresh storage, opens the link.
+  await setupUser(page, { name: 'Bob', email: 'bob@example.com' });
+  page.on('dialog', (d) => d.accept()); // the "imported ✓" alert
+  await page.goto(shareUrl);
+
+  await expect(page.locator('.trip-card', { hasText: 'Shared Trip' })).toBeVisible();
+  await page.locator('.trip-card', { hasText: 'Shared Trip' }).click();
+  await expect(page.locator('.tx-card', { hasText: 'Dinner' })).toBeVisible();
+  await expect(page.locator('.tx-amount')).toHaveText('€10.00');
+});
+
+test('re-importing the same link does not duplicate data', async ({ page }) => {
+  const shareUrl = await makeShareLink(page);
+
+  await setupUser(page, { name: 'Bob', email: 'bob@example.com' });
+  page.on('dialog', (d) => d.accept());
+
+  await page.goto(shareUrl);
+  await expect(page.locator('.trip-card', { hasText: 'Shared Trip' })).toBeVisible();
+
+  // Import the very same link a second time.
+  await page.goto(shareUrl);
+
+  // Still exactly one trip card and, inside it, one transaction.
+  await expect(page.locator('.trip-card', { hasText: 'Shared Trip' })).toHaveCount(1);
+  await page.locator('.trip-card', { hasText: 'Shared Trip' }).click();
+  await expect(page.locator('.tx-card')).toHaveCount(1);
+});

--- a/tests/smoke/helpers.js
+++ b/tests/smoke/helpers.js
@@ -1,0 +1,85 @@
+// @ts-check
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+// file:// URL to the app under test — the app is a single self-contained file.
+const APP_URL = pathToFileURL(
+  path.join(__dirname, '..', '..', 'urunan.html')
+).href;
+
+/**
+ * Load the app fresh (clean localStorage) and complete the one-time user setup
+ * so tests start on the trip-list screen as a logged-in user.
+ */
+async function setupUser(page, { name = 'Alice', email = 'alice@example.com' } = {}) {
+  await page.goto(APP_URL);
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+
+  await page.getByPlaceholder('Your name').fill(name);
+  await page.getByPlaceholder('your@email.com').fill(email);
+  await page.getByRole('button', { name: /Get Started/ }).click();
+
+  // We should now be on the trips screen.
+  await page.getByRole('button', { name: /Create New Trip/ }).waitFor();
+  return { name, email };
+}
+
+/**
+ * Create a trip with the given title and participant emails (besides the
+ * current user, who is added automatically).
+ */
+async function createTrip(page, { title, participants = [] } = {}) {
+  await page.getByRole('button', { name: /Create New Trip/ }).click();
+  await page.getByPlaceholder(/Trip name/).fill(title);
+  for (const email of participants) {
+    await page.getByPlaceholder('friend@email.com').fill(email);
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+  }
+  await page.getByRole('button', { name: 'Save Trip' }).click();
+  await tripCard(page, title).waitFor();
+}
+
+/**
+ * The trip-list card whose name is exactly `title` (exact match so a title
+ * like "Trip" doesn't collide with static UI text such as "Your Trips").
+ */
+function tripCard(page, title) {
+  return page
+    .locator('.trip-card')
+    .filter({ has: page.getByText(title, { exact: true }) });
+}
+
+/**
+ * Open a trip from the trip list by its title.
+ */
+async function openTrip(page, title) {
+  await tripCard(page, title).locator('.trip-card-body').click();
+  await page.getByRole('button', { name: /Back/ }).waitFor();
+}
+
+/**
+ * Add a transaction. `splits` (optional) is a map of email -> amount for a
+ * custom split; when omitted the default even split is used.
+ */
+async function addTransaction(page, { payerName, title, cost, splits = null }) {
+  await page.getByRole('button', { name: /Add Transaction/ }).click();
+  const form = page.locator('.card-form form');
+  await form.locator('select').selectOption({ label: payerName });
+  await form.getByPlaceholder('What was it for?').fill(title);
+  await form.getByPlaceholder('0.00').first().fill(String(cost));
+
+  if (splits) {
+    const rows = form.locator('.split-row');
+    const n = await rows.count();
+    for (let i = 0; i < n; i++) {
+      const label = (await rows.nth(i).locator('.split-name').innerText()).trim();
+      if (splits[label] != null) {
+        await rows.nth(i).locator('input').fill(String(splits[label]));
+      }
+    }
+  }
+  await form.getByRole('button', { name: 'Add Transaction' }).click();
+}
+
+module.exports = { APP_URL, setupUser, createTrip, tripCard, openTrip, addTransaction };


### PR DESCRIPTION
## What

Adds an end-to-end smoke test suite for `urunan.html`, one spec per mandatory feature. The tests drive the app exactly the way it ships — a single self-contained file loaded over a `file://` URL, no server and no build step — using Playwright + Chromium.

Until now the app had no automated tests (per `agent.md`: *"There is no test suite or build to run for the main app"*). These are thin happy-path checks that each feature is wired up and works.

## Coverage — one spec per mandatory feature

| Spec | Mandatory feature |
| --- | --- |
| `01-user-setup.spec.js` | One-time user setup + `localStorage` persistence across reloads; email normalized/lowercased |
| `02-trips.spec.js` | Creating a trip with multiple participants; participants shown by name; persistence |
| `03-transactions.spec.js` | Transactions with even-by-default split, custom split, and validation of over/under-allocation against the total |
| `04-settlement.spec.js` | The minimal "who owes whom" debt summary, "all settled up" state, and settling a trip (locks further edits) |
| `05-share-link.spec.js` | Sharing a trip via link (URL fragment, no server) and merging on import — including that a repeat import never duplicates data |

Optional **live device sync** is intentionally not covered: it is off by default, requires a running relay, and isn't a mandatory feature.

## Result

All 17 tests pass locally (`npm test` in `tests/`, ~7s).

A `Smoke tests` GitHub Actions workflow runs the suite on every push/PR that touches `urunan.html`, the tests, or the workflow itself, and uploads the Playwright report on failure.

## How to run

```bash
cd tests
npm install
npx playwright install chromium   # first run only
npm test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfhmQbhHbq6dFE4iuHQZCH)_