### PR TITLE
docs: explain cross-device sync flow with mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,102 @@ gcloud services enable run.googleapis.com
 gcloud run deploy urunan-sync --source . --region <your-region> --allow-unauthenticated
 ```
 
-**How it syncs:** enabling sync on a trip mints a random room id + encryption
-key; other devices join by opening the `#sync=…` link or scanning its QR. Each
-sync pulls the room, merges it locally, and pushes the merged result back, so
-devices converge without duplicating anything.
+## How device sync works
+
+Sync is **per trip** and **peer-to-peer through a dumb relay**. There is no
+account, no server-side database, and no continuous connection — devices meet in
+a named "room" on the relay, drop off an encrypted copy of the trip, and pick up
+whatever the other device left. Everything below happens inside `urunan.html`
+(search for the `Cloud sync (optional relay)` block); the relay only shuttles
+opaque bytes.
+
+### Starting sync — how a room is created and joined
+
+```mermaid
+flowchart TD
+    A["Device A: tap<br/>Enable device sync"] --> B["genRoomId() → 16 random bytes<br/>genKey() → AES-GCM-128 key"]
+    B --> C["Store room + key in localStorage<br/>(urunan_sync, kept out of #trip= shares)"]
+    C --> D["Initial syncNow():<br/>seed the room with the trip"]
+    D --> E["Show join link + QR:<br/>#sync=&lt;room&gt;.&lt;key&gt;"]
+    E -. "link / QR" .-> F["Device B: open<br/>#sync=&lt;room&gt;.&lt;key&gt;"]
+    F --> G["joinSync(): pull room,<br/>decrypt with key from the link,<br/>mergeTrip() into local data"]
+    G --> H["Save same room + key locally,<br/>push merged copy back"]
+    H --> I["Both devices now share the room —<br/>sync runs automatically from here"]
+```
+
+- **How it starts:** enabling sync on a trip mints a random **room id** (16
+  random bytes) and an **AES-GCM-128 key**, both kept in a separate
+  `urunan_sync` localStorage entry so they never leak into `#trip=` link shares
+  or the relayed payload. The join link is `…/#sync=<room>.<key>` — the key
+  travels only in the link/QR, never to the relay.
+- **How a device joins:** opening the `#sync=` link (or scanning its QR) makes
+  the app pull the room, decrypt it with the key from the URL fragment, merge it
+  locally, store the same room+key, and push its merged copy back. Repeat
+  imports never duplicate data.
+
+### What triggers a sync, and how long it takes
+
+A sync is a single **pull → merge → push** cycle (`syncNow`). It fires on:
+
+| Trigger | When |
+|---|---|
+| App launch | `syncAllOnStartup()` pulls every synced trip once, so a cold start shows fresh data |
+| Opening a synced trip | `openTrip()` calls `syncNow` immediately |
+| A local edit | `maybeSync()` — **debounced 1.5 s** after add/edit/delete of a transaction, member changes, or settling |
+| Tab/app regains focus | `visibilitychange` re-syncs the open trip |
+| Manual **🔄 Sync now** button | on demand |
+
+Each cycle is a couple of short HTTPS requests — typically well under a second on
+a normal connection. There is **no polling loop**: nothing runs on a fixed
+timer, so an idle app makes no sync traffic. A re-entrancy guard means only one
+cycle per trip runs at a time, and a push is skipped entirely when the local
+state hasn't changed (fingerprint compare against `lastSynced`).
+
+### The sync cycle — pull, merge, push
+
+```mermaid
+sequenceDiagram
+    participant A as Device A
+    participant R as Relay (in-memory,<br/>5-min TTL)
+    participant B as Device B
+
+    Note over A: local edit → wait 1.5 s (debounce)
+    A->>R: GET /room/&lt;id&gt;
+    R-->>A: latest sealed payload (or 404)
+    Note over A: decrypt + gunzip → mergeTrip()<br/>(union users & transactions,<br/>newer updated_at wins, apply tombstones)
+    Note over A: fingerprint changed?
+    A->>R: PUT /room/&lt;id&gt; (gzip + AES-GCM bytes)
+    R-->>A: 204
+
+    Note over B: opens trip / regains focus / launches
+    B->>R: GET /room/&lt;id&gt;
+    R-->>B: Device A's sealed payload
+    Note over B: decrypt + gunzip → mergeTrip()
+    B->>R: PUT merged copy back
+    R-->>B: 204
+    Note over A,B: both converge — no duplicates
+```
+
+**Merging** (`mergeTrip`) is what makes two-way sync safe without a server
+referee: users and transactions are unioned by id, an edited transaction wins by
+its `updated_at` timestamp, and deletions carry **tombstones**
+(`deleted_tx_ids`, `deleted_user_emails`) so a delete on one device is never
+resurrected by an older copy from another.
+
+### What the relay actually sees
+
+Every payload is compressed and encrypted **in the browser** before it leaves
+the device, so the relay only ever holds ciphertext:
+
+```
+sealed payload = [ gzip flag : 1 byte ] [ IV : 12 bytes ] [ AES-GCM ciphertext ]
+                 trip JSON ──gzip──▶ bytes ──AES-GCM(key)──▶ ciphertext
+```
+
+The key never reaches the relay (it lives only in the `#sync=` link), so the
+relay cannot read a trip even in principle. See
+[`sync-server/server.py`](sync-server/server.py): rooms live in an in-memory
+dict, get a **5-minute TTL**, and are capped at 128 KB per payload.
 
 **Limitations:** the relay only holds the most recent push per room, in memory —
 if it restarts or scales to zero the room empties, but no data is lost because


### PR DESCRIPTION
## Summary

Adds a dedicated **"How device sync works"** section to the README that documents how trip data is synced between devices — how sync starts, what triggers it, how long it takes, and how the data flows — using GitHub-native mermaid diagrams. The docs were written after reading the actual implementation (`Cloud sync` block in `urunan.html` and `sync-server/server.py`), so they match the code.

## What's included

- **Flowchart — starting sync:** how a room is created (`genRoomId` → AES-GCM-128 key), the `#sync=<room>.<key>` link/QR, and how a second device joins and pushes back.
- **Trigger table — how it starts & how long:** the five triggers (app launch, opening a synced trip, a local edit debounced 1.5 s, tab focus, manual "🔄 Sync now"), plus the timing facts — sub-second HTTPS requests, no polling loop, no-op pushes skipped via fingerprint compare.
- **Sequence diagram — the pull → merge → push cycle:** Device A ⇄ relay ⇄ Device B, showing decrypt/gunzip/`mergeTrip` (union users & transactions, newest `updated_at` wins, tombstones for deletes) and convergence without duplicates.
- **Payload layout:** ASCII diagram of the sealed payload (`[gzip flag][IV:12][AES-GCM ciphertext]`) and what the relay can/can't see (in-memory rooms, 5-min TTL, 128 KB cap, key never leaves the link).

Docs-only change — no code touched. The existing "Limitations" note is preserved. Code is referenced by section name rather than line number so it won't rot.

## Verification

Mermaid blocks use standard `flowchart TD` / `sequenceDiagram` syntax with quoted labels and HTML-escaped angle brackets, and the code fences balance. I couldn't render them headlessly here, so a quick glance at the rendered README on GitHub is worthwhile to confirm the diagrams display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1UUqG88Q9pqjhr7cWhDWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1UUqG88Q9pqjhr7cWhDWa)_