### PR TITLE
fix: repair mermaid sequence diagram + add GitHub link to app footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ sequenceDiagram
     participant B as Device B
 
     Note over A: local edit → wait 1.5 s (debounce)
-    A->>R: GET /room/&lt;id&gt;
+    A->>R: GET /room/{id}
     R-->>A: latest sealed payload (or 404)
     Note over A: decrypt + gunzip → mergeTrip()<br/>(union users & transactions,<br/>newer updated_at wins, apply tombstones)
     Note over A: fingerprint changed?
-    A->>R: PUT /room/&lt;id&gt; (gzip + AES-GCM bytes)
+    A->>R: PUT /room/{id} (gzip + AES-GCM bytes)
     R-->>A: 204
 
     Note over B: opens trip / regains focus / launches
-    B->>R: GET /room/&lt;id&gt;
+    B->>R: GET /room/{id}
     R-->>B: Device A's sealed payload
     Note over B: decrypt + gunzip → mergeTrip()
     B->>R: PUT merged copy back

--- a/urunan.html
+++ b/urunan.html
@@ -330,7 +330,19 @@ input, select { -webkit-appearance: none; appearance: none; }
   text-align: center;
   font-size: 0.75rem;
   color: var(--gray-300);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
+.footer a.gh-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--gray-300);
+  transition: color 0.15s;
+}
+.footer a.gh-link:hover { color: var(--gray-500, #6b7280); }
+.footer a.gh-link svg { width: 1rem; height: 1rem; fill: currentColor; }
 
 /* ── Utilities ────────────────────────────── */
 .mt-1 { margin-top: 0.25rem; }
@@ -671,7 +683,14 @@ input, select { -webkit-appearance: none; appearance: none; }
     </div>
   </div>
 
-  <div class="footer">Urunan · Data saved on this device</div>
+  <div class="footer">
+    <span>Urunan · Data saved on this device</span>
+    <a class="gh-link" href="https://github.com/rezpaditya/Urunan"
+       target="_blank" rel="noopener noreferrer"
+       title="View source on GitHub" aria-label="View source on GitHub">
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+    </a>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
Follow-up to #67 (already merged).

## Fixes

### 1. README sync-cycle diagram failed to render on GitHub
The sequence diagram showed **"Unable to render rich display — Parse error on line 7"**. Cause: the message text used HTML entities (`GET /room/&lt;id&gt;`), and the `;` inside `&lt;`/`&gt;` is a **statement separator** in mermaid sequence diagrams, so mermaid split the message and choked. Replaced with `/room/{id}` in all three message lines.

Verified by rendering both diagrams (flowchart + sequence) with `@mermaid-js/mermaid-cli` — both now produce SVG with no parse errors.

### 2. Add a GitHub link to the app footer
Small GitHub mark next to the footer text in `urunan.html`, linking to the project repo (`https://github.com/rezpaditya/Urunan`, opens in a new tab) so contributors can reach the source. Styled to inherit the muted footer color with a hover state; 16×16, `aria-label` for accessibility.

Verified by loading `urunan.html` in a headless browser: footer renders, link points at the repo, icon is 16×16, no console errors.

## Verification
- `mermaid-cli` renders both README diagrams cleanly.
- Playwright load of `urunan.html`: footer + GitHub link present and correct, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1UUqG88Q9pqjhr7cWhDWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1UUqG88Q9pqjhr7cWhDWa)_