### PR TITLE
Simplify sync recovery to one-tap email restore (drop passphrase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ localStorage.
 - **On your phone:** open the live URL in Safari/Chrome, then *Share → Add to
   Home Screen* to get a full-screen app icon. The app shows a one-time hint for
   this on the trips screen. On iOS the installed app starts with empty storage —
-  bring your synced trips over with
-  [email + passphrase recovery](#recovering-synced-trips-on-a-new-device).
+  log in with the same email and tap **Restore synced trips** to bring them over
+  ([email restore](#recovering-synced-trips-on-a-new-device)).
 - **Offline / no hosting:** download `urunan.html` and open it in any browser.
   Everything works from a `file://` URL too.
 
@@ -34,9 +34,9 @@ localStorage.
 - **Optional live device sync** — enable it on a trip and changes flow
   both ways automatically across your devices via a tiny relay you host
   (see below). Off by default; the app is fully usable without it.
-- **Email + passphrase recovery** — restore every synced trip on a brand-new
-  device (e.g. a freshly installed home-screen app that started with empty
-  storage) by entering your email and a recovery passphrase. See
+- **One-tap email restore** — restore every synced trip on a brand-new device
+  (e.g. a freshly installed home-screen app that started with empty storage) by
+  logging in with the same email and tapping **Restore**. See
   [Recovering synced trips](#recovering-synced-trips-on-a-new-device).
 - Works offline; data persists in localStorage per device
 
@@ -173,29 +173,28 @@ Sync creds (the random room id + key) live in each device's `localStorage`. A
 brand-new device therefore doesn't know them — most visibly when you **Add
 Urunan to your Home Screen on iOS**, where the installed web app gets its own
 storage partition separate from Safari and starts empty. The join link/QR is one
-way back; **email + passphrase recovery** is the other.
+way back; **email restore** is the simpler one.
 
-- **Setting up:** the first time you enable sync you're asked for a one-time
-  **recovery passphrase**. From it (plus your email) the app derives a private
-  "inbox" — another room on the same relay — that holds an encrypted list of
-  every synced trip's room + key. Active devices refresh it automatically.
-- **Restoring:** on the new device, set up with the same email, tap **🔄 Restore
-  synced trips**, and enter your email + passphrase. The app re-derives the
-  inbox, pulls the manifest, and re-joins every trip.
-- **Already had synced trips (upgrading)?** Trips synced before this feature
-  existed have no inbox, and there is no server-side lookup from email alone, so
-  they can't be restored by email until you set a passphrase. On a device that
-  still has the trip, open its **Share** panel and tap **Set up recovery** to
-  choose a passphrase and publish your synced trips to the inbox — then email +
-  passphrase recovery works on your other devices.
-- **Privacy:** the inbox room id *and* its encryption key are both derived from
-  `email + passphrase` via PBKDF2. Email alone (which is public) can neither
-  locate nor read anything — the passphrase is the secret, so end-to-end
-  encryption is preserved. The passphrase can't be reset; keep it safe.
-- **Same in-memory model:** the inbox is just another relayed room, so it lives
-  only in relay memory and stays reachable only while one of your devices has
-  pushed recently. Recovery works best right after opening the app on a device
-  that still has the trips.
+- **How it works:** whenever you enable or join sync, the app publishes an
+  "inbox" — a room on the same relay whose id is derived from your email — that
+  lists every synced trip's room + key. It's kept fresh automatically by any
+  active device. No setup, no passphrase.
+- **Restoring:** on the new device, set up (log in) with the **same email**,
+  then tap **🔄 Restore synced trips** (also offered right in the empty state and
+  in the Add-to-Home-Screen hint). The app reads the inbox for your email and
+  re-joins every trip. One tap, done.
+- **In-memory model:** the inbox is just another relayed room, so it lives only
+  in relay memory and stays reachable only while one of your devices has pushed
+  recently. Restore works best right after opening the app on a device that still
+  has the trips.
+- **Privacy trade-off:** the inbox room id and its encryption key are derived
+  from your **email alone**, which is not secret. This is a deliberate choice for
+  one-tap restore: anyone who knows your email could pull your *synced* trips
+  from the relay while it's warm. The relay itself still can't read anything (it
+  only ever sees an opaque room id + ciphertext and never learns your email), and
+  trips you haven't synced are unaffected. If you need synced data to stay
+  end-to-end private, share the `#sync=` join link/QR by hand instead of relying
+  on email restore.
 
 ## Development
 

--- a/urunan.html
+++ b/urunan.html
@@ -413,9 +413,8 @@ input, select { -webkit-appearance: none; appearance: none; }
         In Safari, tap the <b>Share</b> button (□↑) then <b>"Add to Home Screen"</b> — Urunan will appear as an app icon you can tap directly.
         <span v-if="syncAvailable" class="install-restore-hint">
           The installed app starts with its own empty storage. If your trips
-          don't appear there, tap
-          <button type="button" class="link-btn" @click="openRestore">Restore synced trips</button>
-          and enter your recovery passphrase.
+          don't appear there, just tap
+          <button type="button" class="link-btn" @click="restoreMyTrips" :disabled="restoring">Restore synced trips</button>.
         </span>
       </div>
       <button class="install-close" @click="dismissInstallBanner">×</button>
@@ -424,7 +423,7 @@ input, select { -webkit-appearance: none; appearance: none; }
     <div class="section-row">
       <span class="section-title">Your Trips</span>
       <button v-if="syncAvailable" type="button" class="link-btn" style="font-size:0.8125rem"
-              @click="openRestore">🔄 Restore synced trips</button>
+              @click="restoreMyTrips" :disabled="restoring">{{ restoring ? '⟳ Restoring…' : '🔄 Restore synced trips' }}</button>
     </div>
 
     <!-- Create trip toggle -->
@@ -463,6 +462,14 @@ input, select { -webkit-appearance: none; appearance: none; }
     <div v-if="myTrips.length === 0 && !showAddTrip" class="empty" style="flex:1">
       <div class="empty-icon">🧳</div>
       <div class="empty-text">No trips yet.<br>Create one above!</div>
+      <button v-if="syncAvailable" type="button" class="btn btn-secondary" style="margin-top:1rem"
+              @click="restoreMyTrips" :disabled="restoring">
+        {{ restoring ? '⟳ Restoring…' : '🔄 Restore my synced trips' }}
+      </button>
+      <div v-if="syncAvailable" class="field-hint" style="margin-top:0.5rem;max-width:20rem">
+        Already synced trips on another device? Log in with the same email and
+        tap to bring them here.
+      </div>
     </div>
 
     <div v-for="trip in myTrips" :key="trip.id" class="trip-card">
@@ -657,11 +664,9 @@ input, select { -webkit-appearance: none; appearance: none; }
             <button class="btn btn-secondary" @click="syncNowCurrent">🔄 Sync now</button>
             <button class="btn btn-ghost" @click="disableSyncCurrent">Turn off</button>
           </div>
-          <p v-if="!hasRecovery" class="field-hint" style="margin-top:0.5rem">
-            💡 Set a <b>recovery passphrase</b> so you can restore this trip on a new
-            device with just your email + passphrase (handy after adding Urunan to
-            your home screen).
-            <button type="button" class="link-btn" @click="setupRecovery">Set up recovery</button>
+          <p class="field-hint" style="margin-top:0.5rem">
+            💡 On a new device, log in with your email and tap <b>Restore synced
+            trips</b> to bring this trip over — no link needed.
           </p>
         </template>
       </div>
@@ -725,39 +730,6 @@ input, select { -webkit-appearance: none; appearance: none; }
         <div class="modal-actions" style="margin-top:0.875rem">
           <button type="submit" class="btn btn-primary">Save changes</button>
           <button type="button" class="btn btn-secondary" @click="editTripModal = false">Cancel</button>
-        </div>
-      </form>
-    </div>
-  </div>
-
-  <!-- Restore synced trips (email + passphrase) -->
-  <div v-if="showRestoreModal" class="modal-backdrop" @click.self="showRestoreModal = false">
-    <div class="modal">
-      <h3 class="section-title" style="margin-bottom:0.5rem">🔄 Restore synced trips</h3>
-      <p class="field-hint" style="margin-top:0">
-        Bring back every trip you've enabled sync for on this device using your
-        email and the recovery passphrase you set. Works on a freshly installed
-        home-screen app that started empty — but only while another of your
-        devices has synced recently.
-      </p>
-      <form class="form" @submit.prevent="doRestore">
-        <div class="field-label" style="margin-top:0.5rem">Email</div>
-        <input v-model="restoreForm.email" class="input" type="email" required
-               placeholder="your@email.com" autocomplete="email">
-
-        <div class="field-label" style="margin-top:0.5rem">Recovery passphrase</div>
-        <input v-model="restoreForm.passphrase" class="input" type="password" required
-               placeholder="Your recovery passphrase" autocomplete="off">
-
-        <p v-if="restoreForm.error" class="field-hint" style="color:var(--red);margin-top:0.5rem">
-          {{ restoreForm.error }}
-        </p>
-
-        <div class="modal-actions" style="margin-top:0.875rem">
-          <button type="submit" class="btn btn-primary" :disabled="restoreForm.busy">
-            {{ restoreForm.busy ? 'Restoring…' : 'Restore' }}
-          </button>
-          <button type="button" class="btn btn-secondary" @click="showRestoreModal = false">Cancel</button>
         </div>
       </form>
     </div>
@@ -3108,8 +3080,7 @@ createApp({
     const editingTxId = ref(null);          // id of the transaction being edited, or null
     const editTripModal = ref(false);       // edit-trip modal (name/description/members)
     const showInstallBanner = ref(false);   // "Add to Home Screen" hint on the trips screen
-    const showRestoreModal = ref(false);    // "Restore synced trips" (email + passphrase) modal
-    const restoreForm = reactive({ email: '', passphrase: '', busy: false, error: '' });
+    const restoring = ref(false);           // "Restore synced trips" in-flight flag
 
     const setupForm = reactive({ name: '', email: '' });
     const tripForm  = reactive({ title: '', text: '', participantInput: '', participants: [] });
@@ -3750,39 +3721,32 @@ createApp({
       }
     };
 
-    // ── Recovery inbox (email + passphrase) ────────────────────
-    // A per-user "inbox" room on the same relay whose id AND key are derived
-    // from email + a recovery passphrase (PBKDF2). It holds an encrypted
-    // manifest of every synced trip's creds, so a blank device — e.g. a
-    // freshly installed home-screen PWA that can't see the browser's
-    // localStorage — can re-enter email + passphrase and pull all its synced
-    // trips back. Email alone never locates or decrypts anything: the
-    // passphrase is the secret, so end-to-end encryption is preserved. The
-    // inbox is just another relayed room, so it too lives only in relay
-    // memory (kept warm by active devices), never on disk.
-    const PBKDF2_ITERS = 200000;
-    const deriveInbox = async (email, passphrase) => {
-      const enc = new TextEncoder();
+    // ── Recovery inbox (email-keyed) ───────────────────────────
+    // A per-user "inbox" room on the same relay, addressed entirely by the
+    // user's email. It holds a manifest of every synced trip's creds, so a
+    // blank device — e.g. a freshly installed home-screen PWA that can't see
+    // the browser's localStorage — restores all synced trips by just logging
+    // in with the same email and tapping Restore. No passphrase, no extra
+    // steps. The inbox is established automatically whenever sync is enabled
+    // or joined; devices keep it warm in relay memory (never on disk).
+    //
+    // TRADE-OFF: because the inbox room id and key derive from the email
+    // alone (which is not secret), anyone who knows your email could pull your
+    // synced trips from the relay while it's warm. This deliberately drops the
+    // end-to-end privacy of synced data in favour of one-tap restore. The
+    // relay still can't read anything (it never learns the email, only an
+    // opaque room id + ciphertext), and unsynced trips are unaffected.
+    const deriveInbox = async email => {
       const norm = String(email).trim().toLowerCase();
-      const baseKey = await crypto.subtle.importKey(
-        'raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveBits']);
-      const bits = new Uint8Array(await crypto.subtle.deriveBits(
-        { name: 'PBKDF2', salt: enc.encode('urunan-inbox|' + norm),
-          iterations: PBKDF2_ITERS, hash: 'SHA-256' },
-        baseKey, 256));                              // 32 bytes
+      const digest = new Uint8Array(await crypto.subtle.digest(
+        'SHA-256', new TextEncoder().encode('urunan-inbox|v1|' + norm)));
       return {
-        room: b64uFromBytes(bits.slice(0, 16)),      // 22-char base64url room id
-        key:  b64uFromBytes(bits.slice(16, 32))      // 128-bit AES-GCM key
+        room: b64uFromBytes(digest.slice(0, 16)),   // 22-char base64url room id
+        key:  b64uFromBytes(digest.slice(16, 32))   // 128-bit AES-GCM key
       };
     };
-
-    // Device-local inbox creds { room, key }, kept separate so they never
-    // leak into #trip=/#sync= shares. Re-derivable from email + passphrase.
-    const inboxMeta = ref((() => {
-      try { return JSON.parse(localStorage.getItem('urunan_inbox')) || null; }
-      catch (e) { return null; }
-    })());
-    const saveInbox = m => { inboxMeta.value = m; localStorage.setItem('urunan_inbox', JSON.stringify(m)); };
+    const currentInbox = async () =>
+      currentUser.value ? deriveInbox(currentUser.value.email) : null;
 
     // The manifest published to the inbox: this device's per-trip sync creds.
     const localManifest = () => {
@@ -3798,8 +3762,9 @@ createApp({
     // devices and refreshes the relay TTL so the inbox stays reachable while
     // any device is active. Best-effort: trip sync works without it.
     const pushInbox = async () => {
-      const inb = inboxMeta.value;
-      if (!inb || !syncAvailable || !navigator.onLine) return;
+      if (!syncAvailable || !navigator.onLine) return;
+      const inb = await currentInbox();
+      if (!inb) return;
       try {
         const merged = { trips: {} };
         const remoteBytes = await relayGet(inb.room);
@@ -3807,48 +3772,28 @@ createApp({
           try {
             const remote = await openJson(remoteBytes, inb.key);
             if (remote && remote.trips) Object.assign(merged.trips, remote.trips);
-          } catch (e) { /* wrong key / corrupt — overwrite with our copy */ }
+          } catch (e) { /* corrupt — overwrite with our copy */ }
         }
         Object.assign(merged.trips, localManifest().trips);   // local wins on conflict
         await relayPut(inb.room, await sealJson(merged, inb.key));
       } catch (e) { /* ignore: recovery is a convenience, not required for sync */ }
     };
 
-    // Set up the recovery inbox on first sync (prompt once for a passphrase).
-    const ensureInbox = async () => {
-      if (inboxMeta.value) return true;
-      if (!currentUser.value) return false;
-      const pass = prompt(
-        'Set a recovery passphrase for cross-device sync.\n\n' +
-        'You\'ll enter your email + this passphrase to restore your synced ' +
-        'trips on a new device (for example after adding Urunan to your home ' +
-        'screen). It cannot be reset, so keep it safe.\n\n' +
-        'Passphrase (at least 6 characters):');
-      if (pass === null) return false;                   // cancelled
-      if (pass.trim().length < 6) { alert('Passphrase must be at least 6 characters.'); return false; }
-      saveInbox(await deriveInbox(currentUser.value.email, pass.trim()));
-      return true;
-    };
-
-    // Restore every synced trip from the inbox using email + passphrase.
+    // Restore every synced trip from the inbox for the logged-in email.
     // Returns the number of trips found.
-    const restoreFromInbox = async (email, passphrase) => {
+    const restoreFromInbox = async () => {
       if (!syncAvailable) throw new Error('device sync is disabled in this build');
-      const inb = await deriveInbox(email, passphrase);
+      const inb = await currentInbox();
+      if (!inb) throw new Error('set up with your email first');
       const bytes = await relayGet(inb.room);
-      // Room id and key both derive from email + passphrase, so a wrong
-      // passphrase lands on a different (empty) room. A 404 therefore means
-      // either the passphrase is wrong or no device has refreshed the inbox
-      // recently — surface both.
       if (!bytes) throw new Error(
-        'Couldn\'t find your synced trips. Double-check your recovery passphrase, ' +
-        'or open Urunan on a device that still has them so it can refresh, then try again.');
+        'No synced trips found for this email. Open Urunan on a device that still ' +
+        'has them so it can refresh, then try again.');
       let manifest;
       try { manifest = await openJson(bytes, inb.key); }
-      catch (e) { throw new Error('Wrong email or recovery passphrase.'); }
+      catch (e) { manifest = null; }
       if (!manifest || typeof manifest !== 'object' || !manifest.trips)
-        throw new Error('Wrong email or recovery passphrase.');
-      saveInbox(inb);
+        throw new Error('Could not read your synced trips — the recovery data looks corrupt.');
       let found = 0;
       for (const [tid, m] of Object.entries(manifest.trips)) {
         if (!m || !m.room || !m.key) continue;
@@ -3864,8 +3809,7 @@ createApp({
       syncMeta[String(tripId)] = { room: genRoomId(), key: await genKey(), lastSynced: '' };
       saveSyncMeta();
       await syncNow(tripId);           // initial push seeds the room
-      await ensureInbox();             // set up the recovery inbox on first sync
-      pushInbox();                     // publish this trip's creds to the inbox
+      pushInbox();                     // publish this trip's creds to the email inbox
     };
     const joinSync = async (room, key) => {
       const bytes = await relayGet(room);
@@ -3881,7 +3825,7 @@ createApp({
         }
       }
       await syncNow(merged.id);         // push our merged state back
-      pushInbox();                      // include this trip in the recovery inbox (if set up)
+      pushInbox();                      // include this trip in the email inbox
       return merged;
     };
     const disableSync = tripId => {
@@ -3890,39 +3834,20 @@ createApp({
       delete syncStates[String(tripId)];
     };
 
-    // Restore-modal wiring.
-    const openRestore = () => {
-      restoreForm.email = currentUser.value ? currentUser.value.email : '';
-      restoreForm.passphrase = '';
-      restoreForm.error = '';
-      restoreForm.busy = false;
-      showRestoreModal.value = true;
-    };
-    const doRestore = async () => {
-      restoreForm.error = '';
-      restoreForm.busy = true;
+    // One-tap restore using the logged-in email.
+    const restoreMyTrips = async () => {
+      if (restoring.value) return;
+      restoring.value = true;
       try {
-        const n = await restoreFromInbox(restoreForm.email.trim().toLowerCase(), restoreForm.passphrase);
-        showRestoreModal.value = false;
+        const n = await restoreFromInbox();
         alert(n
           ? `Restored ${n} synced trip${n === 1 ? '' : 's'} ✓`
-          : 'No synced trips were listed for this account.');
+          : 'No synced trips were listed for this email.');
       } catch (e) {
-        restoreForm.error = e.message || String(e);
+        alert(e.message || String(e));
       } finally {
-        restoreForm.busy = false;
+        restoring.value = false;
       }
-    };
-
-    // Recovery is "set up" once this device has an inbox. Trips synced under
-    // an earlier release (before the passphrase existed) have none, so offer a
-    // one-off way to establish it and publish the already-synced trips.
-    const hasRecovery = computed(() => !!inboxMeta.value);
-    const setupRecovery = async () => {
-      const ok = await ensureInbox();
-      if (!ok) return;
-      await pushInbox();
-      alert('Recovery is set up ✓ — restore your synced trips on another device with your email + this passphrase.');
     };
 
     // Modal-facing wrappers (operate on the open trip).
@@ -4014,8 +3939,7 @@ createApp({
       syncAvailable, currentTripSynced, currentSyncState, syncChip, syncUrl, syncQrSvg,
       enableSyncCurrent, syncNowCurrent, disableSyncCurrent, copySyncLink, shareSyncLink,
       showInstallBanner, dismissInstallBanner,
-      showRestoreModal, restoreForm, openRestore, doRestore,
-      hasRecovery, setupRecovery,
+      restoring, restoreMyTrips,
       tripTotal, displayName, completeSetup, logout,
       addParticipant, removeParticipant, createTrip, confirmDeleteTrip, openTrip,
       addTransaction, toggleAddTransaction, startEditTransaction,


### PR DESCRIPTION
Follow-up to #69 (now merged). That version required a **recovery passphrase** set from inside the Share modal — hard to find, and extra friction. Since the app's identity is already just an email with no auth, this makes recovery **email-only and one tap**.

## What changed

- **No passphrase.** The recovery "inbox" room id + key are derived from the **email alone** (SHA-256). The inbox is established **automatically** whenever you enable or join sync — no setup step.
- **One-tap restore** on a blank device: log in with the same email, tap **🔄 Restore synced trips**. The button is surfaced where you'd actually look for it:
  - prominently in the **empty state** ("No trips yet"),
  - in the **trips header**,
  - in the **Add-to-Home-Screen hint**.
- **Removed** the passphrase restore modal and the buried "Set up recovery" action from the Share modal.

## Flow

1. Enable sync on any device (as before) — the app quietly publishes an email‑keyed inbox listing your synced trips' creds.
2. On a new device or a freshly installed home‑screen PWA, log in with the **same email** → **Restore** → every synced trip returns.

## Security trade-off (deliberate, per maintainer request)

Because the inbox is derived from the email — which isn't secret — **anyone who knows your email could pull your *synced* trips from the relay while it's warm**. This intentionally drops the end‑to‑end privacy of *synced* data in exchange for one‑tap restore. Mitigations/notes:

- The relay still **never learns your email or sees plaintext** — it only ever handles an opaque room id + ciphertext, and the email→room mapping is a one‑way hash it can't reverse.
- **Unsynced trips are unaffected.**
- The hand‑shared `#sync=` join link/QR (random room + key) remains available for anyone who wants synced data to stay end‑to‑end private.

This is documented inline in `urunan.html` and in the README's recovery section.

## Verification

- **17/17 smoke tests pass** (`cd tests && npm test`).
- **End-to-end** (in-memory relay, out of tree): enabling sync prompts for **no passphrase**; a blank device restores every synced trip with **one tap** by logging in with the same email; restored trips **persist across reload**; an **unknown email** restores nothing with a clear message.

## Files

- `urunan.html` — email-only `deriveInbox` (SHA-256); auto `pushInbox` on enable/join/startup; one-tap `restoreMyTrips`; restore buttons in empty state / header / install hint; removed passphrase modal + "Set up recovery".
- `README.md` — recovery section rewritten for email-only restore, including the privacy trade-off.

## Relationship to #69

Supersedes the passphrase UX from #69 (which is already merged into `main`). This PR branches from `main` and keeps the underlying inbox/manifest mechanism, changing only the key derivation and the UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019zWRkZ639hE3eSosD6Qrjq)_